### PR TITLE
QOL-5710 ignore auth checks on loading user details during password resets, #5185

### DIFF
--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -567,10 +567,12 @@ class PerformResetView(MethodView):
         except logic.NotAuthorized:
             base.abort(403, _(u'Unauthorized to reset password.'))
 
+        context[u'ignore_auth'] = True
         try:
             user_dict = logic.get_action(u'user_show')(context, {u'id': id})
         except logic.NotFound:
             base.abort(404, _(u'User not found'))
+        del context[u'ignore_auth']
         user_obj = context[u'user_obj']
         g.reset_key = request.params.get(u'key')
         if not mailer.verify_reset_link(user_obj, g.reset_key):


### PR DESCRIPTION
Already fixed sending the password reset link, but also need to fix actually using it.