### PR TITLE
Fix CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: python:2
+      - image: python:2-stretch
         environment:
           CKAN_DATASTORE_POSTGRES_DB: datastore_test
           CKAN_DATASTORE_POSTGRES_READ_USER: datastore_read


### PR DESCRIPTION
- CKAN master has a number of changes to the CI config, some of which we may need to backport to make 2.8.3 tests work.