### PR TITLE
[QOL-5909] allow sysadmins to edit usernames

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -638,7 +638,7 @@ def user_update(context, data_dict):
     '''Update a user account.
 
     Normal users can only update their own user accounts. Sysadmins can update
-    any user account. Can not modify exisiting user's name.
+    any user account and modify existing usernames.
 
     For further parameters see
     :py:func:`~ckan.logic.action.create.user_create`.

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -557,10 +557,13 @@ def user_name_validator(key, data, errors, context):
             return
         else:
             # Otherwise return an error: there's already another user with that
-            # name, so you can create a new user with that name or update an
+            # name, so you can't create a new user with that name or update an
             # existing user's name to that name.
             errors[key].append(_('That login name is not available.'))
     elif user_obj_from_context:
+        requester = context.get('auth_user_obj', None)
+        if requester and requester.sysadmin == True:
+            return
         old_user = model.User.get(user_obj_from_context.id)
         if old_user is not None and old_user.state != model.State.PENDING:
             errors[key].append(_('That login name can not be modified.'))

--- a/ckan/templates-bs2/user/edit_user_form.html
+++ b/ckan/templates-bs2/user/edit_user_form.html
@@ -5,7 +5,11 @@
 
   <fieldset>
     <legend>{{ _('Change details') }}</legend>
-    {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': ''}) }}
+    {% if c.userobj.sysadmin == True %}
+      {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], is_required=true) }}
+    {% else %}
+      {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': ''}) }}
+    {% endif %}
 
     {{ form.input('fullname', label=_('Full name'), id='field-fullname', value=data.fullname, error=errors.fullname, placeholder=_('eg. Joe Bloggs'), classes=['control-medium']) }}
 

--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -5,7 +5,11 @@
 
   <fieldset>
     <legend>{{ _('Change details') }}</legend>
-    {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': '', 'class': 'form-control'}) }}
+    {% if c.userobj.sysadmin == True %}
+      {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], is_required=true, attrs={'class': 'form-control'}) }}
+    {% else %}
+      {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': '', 'class': 'form-control'}) }}
+    {% endif %}
 
     {{ form.input('fullname', label=_('Full name'), id='field-fullname', value=data.fullname, error=errors.fullname, placeholder=_('eg. Joe Bloggs'), classes=['control-medium']) }}
 

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -446,7 +446,8 @@ class TestUserEdit(helpers.FunctionalTestBase):
         # new values
         form['name'] = 'new-name'
         env = {'REMOTE_USER': user['name'].encode('ascii')}
-        response = webtest_submit(form, 'save', status=200, extra_environ=env)
+        response = webtest_submit(form, 'save', status=302, extra_environ=env)
+        response = response.follow()
         assert_true('Profile updated' in response)
 
     def test_perform_reset_for_key_change(self):

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -447,7 +447,7 @@ class TestUserEdit(helpers.FunctionalTestBase):
         form['name'] = 'new-name'
         env = {'REMOTE_USER': user['name'].encode('ascii')}
         response = webtest_submit(form, 'save', status=302, extra_environ=env)
-        response = response.follow()
+        response = response.follow(extra_environ=env)
         assert_true('Profile updated' in response)
 
     def test_perform_reset_for_key_change(self):

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -338,7 +338,7 @@ class TestUserEdit(helpers.FunctionalTestBase):
         user = factories.User(password=user_pass)
         app = self._get_test_app()
 
-        # Have to do an actual login as this test relys on repoze cookie handling.
+        # Have to do an actual login as this test relies on repoze cookie handling.
         # get the form
         response = app.get('/user/login')
         # ...it's the second one
@@ -367,7 +367,7 @@ class TestUserEdit(helpers.FunctionalTestBase):
         user = factories.User(password=user_pass)
         app = self._get_test_app()
 
-        # Have to do an actual login as this test relys on repoze cookie handling.
+        # Have to do an actual login as this test relies on repoze cookie handling.
         # get the form
         response = app.get('/user/login')
         # ...it's the second one
@@ -396,7 +396,7 @@ class TestUserEdit(helpers.FunctionalTestBase):
         user = factories.User(password=user_pass)
         app = self._get_test_app()
 
-        # Have to do an actual login as this test relys on repoze cookie handling.
+        # Have to do an actual login as this test relies on repoze cookie handling.
         # get the form
         response = app.get('/user/login')
         # ...it's the second one
@@ -419,6 +419,34 @@ class TestUserEdit(helpers.FunctionalTestBase):
         env = {'REMOTE_USER': user['name'].encode('ascii')}
         response = webtest_submit(form, 'save', status=200, extra_environ=env)
         assert_true('That login name can not be modified' in response)
+
+    def test_edit_user_logged_in_username_change_by_sysadmin(self):
+        user = factories.Sysadmin()
+        app = self._get_test_app()
+
+        # Have to do an actual login as this test relies on repoze cookie handling.
+        # get the form
+        response = app.get('/user/login')
+        # ...it's the second one
+        login_form = response.forms[1]
+        # fill it in
+        login_form['login'] = user['name']
+        login_form['password'] = user['password']
+        # submit it
+        login_form.submit()
+
+        # Now the cookie is set, run the test
+        response = app.get(
+            url=url_for('user.edit', id=user['id']),
+        )
+        # existing values in the form
+        form = response.forms['user-edit-form']
+
+        # new values
+        form['name'] = 'new-name'
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = webtest_submit(form, 'save', status=200, extra_environ=env)
+        assert_true('Profile updated' in response)
 
     def test_perform_reset_for_key_change(self):
         password = 'TestPassword1'

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -436,18 +436,20 @@ class TestUserEdit(helpers.FunctionalTestBase):
         # submit it
         login_form.submit()
 
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
         # Now the cookie is set, run the test
         response = app.get(
-            url=url_for('user.edit', id=user['id']),
+            url=url_for('user.edit', id=user['id']), extra_environ=env,
         )
         # existing values in the form
         form = response.forms['user-edit-form']
 
         # new values
         form['name'] = 'new-name'
-        env = {'REMOTE_USER': user['name'].encode('ascii')}
-        response = submit_and_follow(app, form, extra_environ=env, name='save')
-        assert_true('Profile updated' in response)
+        response = submit_and_follow(app, form, env, 'save')
+
+        user = model.Session.query(model.User).get(user['id'])
+        assert_equal(user.name, 'new-name')
 
     def test_perform_reset_for_key_change(self):
         password = 'TestPassword1'

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -448,8 +448,10 @@ class TestUserEdit(helpers.FunctionalTestBase):
         form['name'] = 'new-name'
         response = webtest_submit(form, 'save', status=302, extra_environ=env)
         env['REMOTE_USER'] = 'new-name'
-        response = app.get(url=response.headers['Location'],
-                   extra_environ=env)
+        response = app.get(
+            url=response.headers['Location'],
+            extra_environ=env
+        )
         assert_true('Profile updated' in response)
 
     def test_perform_reset_for_key_change(self):

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -446,8 +446,7 @@ class TestUserEdit(helpers.FunctionalTestBase):
         # new values
         form['name'] = 'new-name'
         env = {'REMOTE_USER': user['name'].encode('ascii')}
-        response = webtest_submit(form, 'save', status=302, extra_environ=env)
-        response = response.follow(extra_environ=env)
+        response = submit_and_follow(app, form, extra_environ=env, name='save')
         assert_true('Profile updated' in response)
 
     def test_perform_reset_for_key_change(self):

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -446,10 +446,11 @@ class TestUserEdit(helpers.FunctionalTestBase):
 
         # new values
         form['name'] = 'new-name'
-        response = submit_and_follow(app, form, env, 'save')
-
-        user = model.Session.query(model.User).get(user['id'])
-        assert_equal(user.name, 'new-name')
+        response = webtest_submit(form, 'save', status=302, extra_environ=env)
+        env['REMOTE_USER'] = 'new-name'
+        response = app.get(url=response.headers['Location'],
+                   extra_environ=env)
+        assert_true('Profile updated' in response)
 
     def test_perform_reset_for_key_change(self):
         password = 'TestPassword1'

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -421,7 +421,8 @@ class TestUserEdit(helpers.FunctionalTestBase):
         assert_true('That login name can not be modified' in response)
 
     def test_edit_user_logged_in_username_change_by_sysadmin(self):
-        user = factories.Sysadmin()
+        user_pass = 'TestPassword1'
+        user = factories.Sysadmin(password=user_pass)
         app = self._get_test_app()
 
         # Have to do an actual login as this test relies on repoze cookie handling.
@@ -431,7 +432,7 @@ class TestUserEdit(helpers.FunctionalTestBase):
         login_form = response.forms[1]
         # fill it in
         login_form['login'] = user['name']
-        login_form['password'] = user['password']
+        login_form['password'] = user_pass
         # submit it
         login_form.submit()
 


### PR DESCRIPTION
There are security risks in allowing just anyone to edit usernames (login cookie forgery),
but sysadmins can already do anything
