### PR TITLE
[QOL-7044] don't update package modification timestamp more than once…

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -308,9 +308,11 @@ def package_update(context, data_dict):
         rev.message = _(u'REST API: Update object %s') % data.get("name")
 
     #avoid revisioning by updating directly
-    model.Session.query(model.Package).filter_by(id=pkg.id).update(
-        {"metadata_modified": datetime.datetime.utcnow()})
-    model.Session.refresh(pkg)
+    now = datetime.datetime.utcnow()
+    if not pkg.metadata_modified or pkg.metadata_modified + datetime.timedelta(seconds=10) < now:
+        model.Session.query(model.Package).filter_by(id=pkg.id).update(
+            {"metadata_modified": now})
+        model.Session.refresh(pkg)
 
     pkg = model_save.package_dict_save(data, context)
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -307,9 +307,12 @@ def package_update(context, data_dict):
     else:
         rev.message = _(u'REST API: Update object %s') % data.get("name")
 
-    #avoid revisioning by updating directly
+    # only update the modification timestamp every few seconds,
+    # to reduce lock contention on datasets with many
+    # frequently updated resources
     now = datetime.datetime.utcnow()
     if not pkg.metadata_modified or pkg.metadata_modified + datetime.timedelta(seconds=10) < now:
+        #avoid revisioning by updating directly
         model.Session.query(model.Package).filter_by(id=pkg.id).update(
             {"metadata_modified": now})
         model.Session.refresh(pkg)


### PR DESCRIPTION
… every ten seconds, #5233

- this should reduce lock contention on resource updates
