### PR TITLE
Incorperate delete() and download() into IUploader, update ResourceUp…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,7 @@ Fixes:
 * Use returned facets in group controller (`#2713 <https://github.com/ckan/ckan/pull/5167>`_)
 * Updated translations
 * Fix broken translation in image view placeholder (`#5099 <https://github.com/ckan/ckan/pull/5116>`_)
+* Update to Interface IUploader, on get_uploader and get_resource_uploader, new method signatures delete(), download(), allowing integration with other cloud storage providers without overriding routes
 
 
 v.2.8.3 2019-07-03

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -1170,29 +1170,29 @@ class PackageController(base.BaseController):
         if rsc.get('url_type') == 'upload':
             upload = uploader.get_resource_uploader(rsc)
             # Be backwards compatible to ensure we have a working system.
-            if hasattr(upload, "download"):
-                try:
-                    return upload.download(rsc['id'], filename)
-                except OSError:
-                    # includes FileNotFoundError
-                    abort(404, _('Resource data not found'))
+            # if hasattr(upload, "download"):
+            try:
+                return upload.download(rsc['id'], filename)
+            except OSError:
+                # includes FileNotFoundError
+                abort(404, _('Resource data not found'))
 
-            else:
-                # To be deprecated once Uploader's have all been upgraded
-                filepath = upload.get_path(rsc['id'])
-                fileapp = paste.fileapp.FileApp(filepath)
-                try:
-                    status, headers, app_iter = \
-                        request.call_application(fileapp)
-                except OSError:
-                    abort(404, _('Resource data not found'))
-                response.headers.update(dict(headers))
-                content_type, content_enc = mimetypes.guess_type(
-                    rsc.get('url', ''))
-                if content_type:
-                    response.headers['Content-Type'] = content_type
-                response.status = status
-                return app_iter
+            # else:
+            #     # To be deprecated once Uploader's have all been upgraded
+            #     filepath = upload.get_path(rsc['id'])
+            #     fileapp = paste.fileapp.FileApp(filepath)
+            #     try:
+            #         status, headers, app_iter = \
+            #             request.call_application(fileapp)
+            #     except OSError:
+            #         abort(404, _('Resource data not found'))
+            #     response.headers.update(dict(headers))
+            #     content_type, content_enc = mimetypes.guess_type(
+            #         rsc.get('url', ''))
+            #     if content_type:
+            #         response.headers['Content-Type'] = content_type
+            #     response.status = status
+            #     return app_iter
         elif 'url' not in rsc:
             abort(404, _('No download is available'))
         h.redirect_to(rsc['url'])

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -1169,19 +1169,30 @@ class PackageController(base.BaseController):
 
         if rsc.get('url_type') == 'upload':
             upload = uploader.get_resource_uploader(rsc)
-            filepath = upload.get_path(rsc['id'])
-            fileapp = paste.fileapp.FileApp(filepath)
-            try:
-                status, headers, app_iter = request.call_application(fileapp)
-            except OSError:
-                abort(404, _('Resource data not found'))
-            response.headers.update(dict(headers))
-            content_type, content_enc = mimetypes.guess_type(
-                rsc.get('url', ''))
-            if content_type:
-                response.headers['Content-Type'] = content_type
-            response.status = status
-            return app_iter
+            # Be backwards compatible to ensure we have a working system.
+            if hasattr(upload, "download"):
+                try:
+                    return upload.download(rsc['id'], filename)
+                except OSError:
+                    # includes FileNotFoundError
+                    abort(404, _('Resource data not found'))
+
+            else:
+                # To be deprecated once Uploader's have all been upgraded
+                filepath = upload.get_path(rsc['id'])
+                fileapp = paste.fileapp.FileApp(filepath)
+                try:
+                    status, headers, app_iter = \
+                        request.call_application(fileapp)
+                except OSError:
+                    abort(404, _('Resource data not found'))
+                response.headers.update(dict(headers))
+                content_type, content_enc = mimetypes.guess_type(
+                    rsc.get('url', ''))
+                if content_type:
+                    response.headers['Content-Type'] = content_type
+                response.status = status
+                return app_iter
         elif 'url' not in rsc:
             abort(404, _('No download is available'))
         h.redirect_to(rsc['url'])

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -1169,30 +1169,11 @@ class PackageController(base.BaseController):
 
         if rsc.get('url_type') == 'upload':
             upload = uploader.get_resource_uploader(rsc)
-            # Be backwards compatible to ensure we have a working system.
-            # if hasattr(upload, "download"):
             try:
                 return upload.download(rsc['id'], filename)
             except OSError:
                 # includes FileNotFoundError
                 abort(404, _('Resource data not found'))
-
-            # else:
-            #     # To be deprecated once Uploader's have all been upgraded
-            #     filepath = upload.get_path(rsc['id'])
-            #     fileapp = paste.fileapp.FileApp(filepath)
-            #     try:
-            #         status, headers, app_iter = \
-            #             request.call_application(fileapp)
-            #     except OSError:
-            #         abort(404, _('Resource data not found'))
-            #     response.headers.update(dict(headers))
-            #     content_type, content_enc = mimetypes.guess_type(
-            #         rsc.get('url', ''))
-            #     if content_type:
-            #         response.headers['Content-Type'] = content_type
-            #     response.status = status
-            #     return app_iter
         elif 'url' not in rsc:
             abort(404, _('No download is available'))
         h.redirect_to(rsc['url'])

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -148,7 +148,7 @@ class Upload(object):
         where the FieldStorage is kept (i.e the field where the file data
         actually is). clear_field is the name of a boolean field which
         requests the upload to be deleted.  This needs to be called before
-        it reaches any validators'''
+      x  it reaches any validators'''
 
         self.url = data_dict.get(url_field, '')
         self.clear = data_dict.pop(clear_field, None)
@@ -181,7 +181,6 @@ class Upload(object):
         been validated and flushed to the db. This is so we do not store
         anything unless the request is actually good.
         max_size is size in MB maximum of the file'''
-
 
         if self.filename:
             with open(self.tmp_filepath, 'wb+') as output_file:

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -148,7 +148,7 @@ class Upload(object):
         where the FieldStorage is kept (i.e the field where the file data
         actually is). clear_field is the name of a boolean field which
         requests the upload to be deleted.  This needs to be called before
-      x  it reaches any validators'''
+        it reaches any validators'''
 
         self.url = data_dict.get(url_field, '')
         self.clear = data_dict.pop(clear_field, None)

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -154,13 +154,15 @@ class Upload(object):
         self.clear = data_dict.pop(clear_field, None)
         self.file_field = file_field
         self.upload_field_storage = data_dict.pop(file_field, None)
+        self.preserve_filename = data_dict.get('preserve_filename', None)
 
         if not self.storage_path:
             return
 
         if isinstance(self.upload_field_storage, (ALLOWED_UPLOAD_TYPES)):
             self.filename = self.upload_field_storage.filename
-            self.filename = str(datetime.datetime.utcnow()) + self.filename
+            if not self.preserve_filename:
+                self.filename = str(datetime.datetime.utcnow()) + self.filename
             self.filename = munge.munge_filename_legacy(self.filename)
             self.filepath = os.path.join(self.storage_path, self.filename)
             data_dict[url_field] = self.filename

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -180,6 +180,7 @@ class Upload(object):
         anything unless the request is actually good.
         max_size is size in MB maximum of the file'''
 
+
         if self.filename:
             with open(self.tmp_filepath, 'wb+') as output_file:
                 try:
@@ -199,21 +200,21 @@ class Upload(object):
             except OSError:
                 pass
 
-    def delete(self):
+    def delete(self, filename):
         ''' Delete file we are pointing at'''
-        try:
-            os.remove(self.filepath)
-        except OSError:
-            pass
+        if not filename.startswith('http'):
+            try:
+                os.remove(filename)
+            except OSError:
+                pass
 
-    def download(self):
+    def download(self, filename):
         ''' Generate file stream or redirect for file'''
-        fileapp = paste.fileapp.FileApp(self.filepath)
+        fileapp = paste.fileapp.FileApp(filename)
 
         status, headers, app_iter = request.call_application(fileapp)
         response.headers.update(dict(headers))
-        content_type, content_enc = mimetypes.guess_type(
-            self.filepath)
+        content_type, content_enc = mimetypes.guess_type(filename)
         if content_type:
             response.headers['Content-Type'] = content_type
         response.status = status

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -11,6 +11,7 @@ import ckan.logic
 import ckan.logic.action
 import ckan.plugins as plugins
 import ckan.lib.dictization.model_dictize as model_dictize
+import ckan.lib.uploader as uploader
 from ckan import authz
 
 from ckan.common import _
@@ -180,6 +181,11 @@ def resource_delete(context, data_dict):
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.before_delete(context, data_dict,
                              pkg_dict.get('resources', []))
+
+    # Delete file if it was uploaded
+    if entity.get('url_type') == 'upload':
+        upload = uploader.get_resource_uploader(entity)
+        upload.delete(id)
 
     if pkg_dict.get('resources'):
         pkg_dict['resources'] = [r for r in pkg_dict['resources'] if not

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -185,7 +185,9 @@ def resource_delete(context, data_dict):
     # Delete file if it was uploaded
     if entity.get('url_type') == 'upload':
         upload = uploader.get_resource_uploader(entity)
-        upload.delete(id)
+        # Don't break if old plugin/interface is found
+        if hasattr(upload, "delete"):
+            upload.delete(id)
 
     if pkg_dict.get('resources'):
         pkg_dict['resources'] = [r for r in pkg_dict['resources'] if not

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -188,6 +188,8 @@ def resource_delete(context, data_dict):
         # Don't break if old plugin/interface is found
         if hasattr(upload, "delete"):
             upload.delete(id)
+        else:
+            logging.warning("%s does not have delete function, could not cleanup: %s", type(upload).__name__, id)
 
     if pkg_dict.get('resources'):
         pkg_dict['resources'] = [r for r in pkg_dict['resources'] if not

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1657,7 +1657,7 @@ class IUploader(Interface):
         ``update_data_dict(data_dict, url_field, file_field, clear_field)``
 
         Allow the data_dict to be manipulated before it reaches any
-        validators.
+        validators. Sets Filename with utcnow date appended if preserve_filename is not set in dict
 
         :param data_dict: data_dict to be updated
         :type data_dict: dictionary

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1680,13 +1680,19 @@ class IUploader(Interface):
         :param max_size: upload size can be limited by this value in MBs.
         :type max_size: int
 
-        ``delete()``
+        ``delete(filename)``
 
         Perform a delete.
 
-        ``download()``
+        :param filename: name of an existing asset, so the extension can delete it
+        :type filename: string
+
+        ``download(filename)``
 
         Provide redirect url or file stream
+
+        :param filename: name of an existing asset, so collect it
+        :type filename: string
 
         '''
 

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1657,9 +1657,8 @@ class IUploader(Interface):
         ``update_data_dict(data_dict, url_field, file_field, clear_field)``
 
         Allow the data_dict to be manipulated before it reaches any
-        validators.
-            Optionally, this data_dict can have following attribute set:
-                    preserve_filename (boolean):  If none, will append utcnow date to Filename
+            validators. Optionally, this data_dict can have following attribute set:
+            preserve_filename (boolean):  If none, will append utcnow date to Filename
 
         :param data_dict: data_dict to be updated
         :type data_dict: dictionary
@@ -1669,7 +1668,7 @@ class IUploader(Interface):
 
         :param file_field: name of the key where the FieldStorage is kept (i.e
             the field where the file data actually is). FileStorage must be an instance of;
-                cgi.FieldStorage or werkzeug.datastructures.FileStorage as FlaskFileStorage
+            cgi.FieldStorage or werkzeug.datastructures.FileStorage as FlaskFileStorage
         :type file_field: string
 
         :param clear_field: name of a boolean field which requests the upload

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1657,7 +1657,9 @@ class IUploader(Interface):
         ``update_data_dict(data_dict, url_field, file_field, clear_field)``
 
         Allow the data_dict to be manipulated before it reaches any
-        validators. Sets Filename with utcnow date appended if preserve_filename is not set in dict
+        validators.
+            Optionally, this data_dict can have following attribute set:
+                    preserve_filename (boolean):  If none, will append utcnow date to Filename
 
         :param data_dict: data_dict to be updated
         :type data_dict: dictionary
@@ -1666,7 +1668,8 @@ class IUploader(Interface):
         :type url_field: string
 
         :param file_field: name of the key where the FieldStorage is kept (i.e
-            the field where the file data actually is).
+            the field where the file data actually is). FileStorage must be an instance of;
+                cgi.FieldStorage or werkzeug.datastructures.FileStorage as FlaskFileStorage
         :type file_field: string
 
         :param clear_field: name of a boolean field which requests the upload
@@ -1684,14 +1687,14 @@ class IUploader(Interface):
 
         Perform a delete.
 
-        :param filename: name of an existing asset, so the extension can delete it
+        :param filename: The filename to use when deleting a file, may be None depending on the storage provider.
         :type filename: string
 
         ``download(filename)``
 
         Provide redirect url or file stream
 
-        :param filename: name of an existing asset, so collect it
+        :param filename: The filename to use when downloading a file, may be None depending on the storage provider.
         :type filename: string
 
         '''
@@ -1731,19 +1734,25 @@ class IUploader(Interface):
         :param id: resource id
         :type id: string
 
-        ``delete(id)``
+        ``delete(id, filename)``
 
         Perform a delete.
 
         :param id: resource id, used to delete file
-        :param filename: can be None.
+        :type id: string
 
-        ``download(id)``
+        :param filename: The filename to use when storing a resource, may be None depending on the storage provider.
+        :type filename: string
+
+        ``download(id, filename)``
 
         Provide redirect url or file stream
 
         :param id: resource id, used to locate file
-        :param filename: can be None.
+        :type id: string
+
+        :param filename: The filename to use when storing a resource, may be None depending on the storage provider.
+        :type filename: string
 
         '''
 

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1657,7 +1657,7 @@ class IUploader(Interface):
         ``update_data_dict(data_dict, url_field, file_field, clear_field)``
 
         Allow the data_dict to be manipulated before it reaches any
-            validators. Optionally, this data_dict can have following attribute set:
+            validators. Optionally, this data_dict can have the following attribute set:
             preserve_filename (boolean):  If none, will append utcnow date to Filename
 
         :param data_dict: data_dict to be updated

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1680,6 +1680,14 @@ class IUploader(Interface):
         :param max_size: upload size can be limited by this value in MBs.
         :type max_size: int
 
+        ``delete()``
+
+        Perform a delete.
+
+        ``download()``
+
+        Provide redirect url or file stream
+
         '''
 
     def get_resource_uploader(self):
@@ -1716,6 +1724,20 @@ class IUploader(Interface):
 
         :param id: resource id
         :type id: string
+
+        ``delete(id)``
+
+        Perform a delete.
+
+        :param id: resource id, used to delete file
+        :param filename: can be None.
+
+        ``download(id)``
+
+        Provide redirect url or file stream
+
+        :param id: resource id, used to locate file
+        :param filename: can be None.
 
         '''
 


### PR DESCRIPTION


Fixes #
Incorporate delete() and download() into IUploader, update ResourceUpload, Upload with functionality from controller resource_download to allow better cloud integrations

### Proposed fixes:
Update IUploader method signagtures for: ResourceUpload, Upload to include delete() and download().

Update controller resource_download to utilise method


### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [x] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
