### PR TITLE
add metadata to uploader interface, next step, surface it via package…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,8 +45,8 @@ Fixes:
 * Updated translations
 * Fix broken translation in image view placeholder (`#5099 <https://github.com/ckan/ckan/pull/5116>`_)
 * Update to Interface IUploader, on get_uploader and get_resource_uploader, new method signatures delete(), download(), allowing integration with other cloud storage providers without overriding routes
-* Update to Interface Iuploader, on get_uploader and get_resource_uploader, new to include new method signature metadata() which can be unitised by archiver and other plugins instead of trying on local disk directly
-* Add api get `resource_file_metadata_show` which takes resource id and returns { 'content_type': content_type, 'size': length, 'hash': hash } if found
+* Update to Interface IUploader, on get_uploader and get_resource_uploader, new to include new method signature metadata() which can be utilised by archiver and other plugins instead of trying on local disk directly
+* Add get api `resource_file_metadata_show` which takes resource id and returns { 'content_type': content_type, 'size': length, 'hash': hash } if found
 
 v.2.8.3 2019-07-03
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,7 +45,8 @@ Fixes:
 * Updated translations
 * Fix broken translation in image view placeholder (`#5099 <https://github.com/ckan/ckan/pull/5116>`_)
 * Update to Interface IUploader, on get_uploader and get_resource_uploader, new method signatures delete(), download(), allowing integration with other cloud storage providers without overriding routes
-
+* Update to Interface Iuploader, on get_uploader and get_resource_uploader, new to include new method signature metadata() which can be unitised by archiver and other plugins instead of trying on local disk directly
+* Add api get `resource_file_metadata_show` which takes resource id and returns { 'content_type': content_type, 'size': length, 'hash': hash } if found
 
 v.2.8.3 2019-07-03
 ==================

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -132,6 +132,7 @@ def _file_hashnlength(local_path):
 
     return (unicode(hasher.hexdigest()), length)
 
+
 class Upload(object):
     def __init__(self, object_type, old_filename=None):
         ''' Setup upload by creating a subdirectory of the storage directory
@@ -228,7 +229,8 @@ class Upload(object):
     def download(self, filename):
         ''' Generate file stream or redirect for file'''
         # Get file from storage_path and filename
-        fileapp = paste.fileapp.FileApp(os.path.join(self.storage_path, filename))
+        fileapp = paste.fileapp.FileApp(
+            os.path.join(self.storage_path, filename))
 
         status, headers, app_iter = request.call_application(fileapp)
         response.headers.update(dict(headers))
@@ -248,8 +250,6 @@ class Upload(object):
         except IOError as e:
             logging.error("Could not retrieve meta data,  IOError thrown", e)
             return e
-
-
 
 
 class ResourceUpload(object):

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -362,3 +362,29 @@ class ResourceUpload(object):
             response.headers['Content-Type'] = content_type
         response.status = status
         return app_iter
+
+    def metadata(self, id, filename=None):
+        ''' Return meta details of file'''
+        try:
+            filepath = self.get_path(id)
+            content_type, content_encoding = mimetypes.guess_type(self.url)
+            hash, length = self._file_hashnlength(filepath)
+            return {'content_type': content_type, 'size': length, 'hash': hash}
+        except IOError as e:
+            logging.error("Could not retrieve meta data,  IOError thrown", e)
+            return e
+
+    def _file_hashnlength(local_path):
+        BLOCKSIZE = 65536
+        hasher = hashlib.sha1()
+        length = 0
+
+        with open(local_path, 'rb') as afile:
+            buf = afile.read(BLOCKSIZE)
+            while len(buf) > 0:
+                hasher.update(buf)
+                length += len(buf)
+
+                buf = afile.read(BLOCKSIZE)
+
+        return (unicode(hasher.hexdigest()), length)

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -117,6 +117,21 @@ def get_max_resource_size():
     return _max_resource_size
 
 
+def _file_hashnlength(local_path):
+    BLOCKSIZE = 65536
+    hasher = hashlib.sha1()
+    length = 0
+
+    with open(local_path, 'rb') as afile:
+        buf = afile.read(BLOCKSIZE)
+        while len(buf) > 0:
+            hasher.update(buf)
+            length += len(buf)
+
+            buf = afile.read(BLOCKSIZE)
+
+    return (unicode(hasher.hexdigest()), length)
+
 class Upload(object):
     def __init__(self, object_type, old_filename=None):
         ''' Setup upload by creating a subdirectory of the storage directory
@@ -205,13 +220,15 @@ class Upload(object):
         ''' Delete file we are pointing at'''
         if not filename.startswith('http'):
             try:
-                os.remove(filename)
+                # Delete file from storage_path and filename
+                os.remove(os.path.join(self.storage_path, filename))
             except OSError:
                 pass
 
     def download(self, filename):
         ''' Generate file stream or redirect for file'''
-        fileapp = paste.fileapp.FileApp(filename)
+        # Get file from storage_path and filename
+        fileapp = paste.fileapp.FileApp(os.path.join(self.storage_path, filename))
 
         status, headers, app_iter = request.call_application(fileapp)
         response.headers.update(dict(headers))
@@ -220,6 +237,19 @@ class Upload(object):
             response.headers['Content-Type'] = content_type
         response.status = status
         return app_iter
+
+    def metadata(self, filename):
+        ''' Return metadata of file'''
+        try:
+            filepath = os.path.join(self.storage_path, filename)
+            content_type, content_encoding = mimetypes.guess_type(filepath)
+            hash, length = _file_hashnlength(filepath)
+            return {'content_type': content_type, 'size': length, 'hash': hash}
+        except IOError as e:
+            logging.error("Could not retrieve meta data,  IOError thrown", e)
+            return e
+
+
 
 
 class ResourceUpload(object):
@@ -368,23 +398,8 @@ class ResourceUpload(object):
         try:
             filepath = self.get_path(id)
             content_type, content_encoding = mimetypes.guess_type(self.url)
-            hash, length = self._file_hashnlength(filepath)
+            hash, length = _file_hashnlength(filepath)
             return {'content_type': content_type, 'size': length, 'hash': hash}
         except IOError as e:
             logging.error("Could not retrieve meta data,  IOError thrown", e)
             return e
-
-    def _file_hashnlength(local_path):
-        BLOCKSIZE = 65536
-        hasher = hashlib.sha1()
-        length = 0
-
-        with open(local_path, 'rb') as afile:
-            buf = afile.read(BLOCKSIZE)
-            while len(buf) > 0:
-                hasher.update(buf)
-                length += len(buf)
-
-                buf = afile.read(BLOCKSIZE)
-
-        return (unicode(hasher.hexdigest()), length)

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1172,7 +1172,7 @@ def resource_file_metadata_show(context, data_dict):
     if not resource:
         raise NotFound
 
-    _check_access('resource_show', resource_context, data_dict)
+    _check_access('resource_file_metadata_show', resource_context, data_dict)
 
 
     upload = uploader.get_resource_uploader(resource)

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -27,6 +27,7 @@ import ckan.lib.search as search
 import ckan.lib.plugins as lib_plugins
 import ckan.lib.activity_streams as activity_streams
 import ckan.lib.datapreview as datapreview
+import ckan.lib.uploader as uploader
 import ckan.authz as authz
 
 from ckan.common import _
@@ -1152,6 +1153,33 @@ def resource_view_list(context, data_dict):
     ]
     return model_dictize.resource_view_list_dictize(resource_views, context)
 
+
+def resource_file_metadata_show(context, data_dict):
+    '''Get file metadata from a resource if it was uploaded.
+
+    :param id: the id of the resource
+    :type id: string
+
+    :returns: the meta data of resource file { 'content_type': content_type, 'size': length, 'hash': hash }
+    :rtype: dictionary
+    '''
+    model = context['model']
+    id = _get_or_bust(data_dict, 'id')
+
+    resource = model.Resource.get(id)
+    resource_context = dict(context, resource=resource)
+
+    if not resource:
+        raise NotFound
+
+    _check_access('resource_show', resource_context, data_dict)
+
+
+    upload = uploader.get_resource_uploader(resource)
+    try:
+        return upload.metadata(id)
+    except IOError:
+        raise NotFound
 
 @logic.auth_audit_exempt
 def revision_show(context, data_dict):

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -177,6 +177,10 @@ def resource_view_list(context, data_dict):
     return authz.is_authorized('resource_show', context, data_dict)
 
 
+def resource_file_metadata_show(context, data_dict):
+    return authz.is_authorized('resource_show', context, data_dict)
+
+
 def revision_show(context, data_dict):
     # No authz check in the logic function
     return {'success': True}

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1696,6 +1696,14 @@ class IUploader(Interface):
         :param filename: The filename to use when downloading a file, may be None depending on the storage provider.
         :type filename: string
 
+        ``metadata(filename)``
+
+        Collect metadata of file. Returns dict { 'content_type': content_type, 'size': length, 'hash': hash }
+        Throws IOError if file does not exist
+
+        :param filename: The filename to use when collecting metadata
+        :type filename: string
+
         '''
 
     def get_resource_uploader(self):
@@ -1751,6 +1759,17 @@ class IUploader(Interface):
         :type id: string
 
         :param filename: The filename to use when storing a resource, may be None depending on the storage provider.
+        :type filename: string
+
+        ``metadata(id, filename)``
+
+        Collect metadata of resource. Returns dict { 'content_type': content_type, 'size': length, 'hash': hash }
+        or None (If file does not exist):
+
+        :param id: resource id, used to locate file
+        :type id: string
+
+        :param filename: The filename to use when collecting metadata, may be None depending on the storage provider.
         :type filename: string
 
         '''

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1764,7 +1764,7 @@ class IUploader(Interface):
         ``metadata(id, filename)``
 
         Collect metadata of resource. Returns dict { 'content_type': content_type, 'size': length, 'hash': hash }
-        or None (If file does not exist):
+        Throws IOError if file does not exist
 
         :param id: resource id, used to locate file
         :type id: string

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1,11 +1,13 @@
 # encoding: utf-8
 
+import __builtin__ as builtins
 import datetime
 
 import nose.tools
 
 from six import text_type
 from six.moves import xrange
+import mock
 
 from ckan import __version__
 import ckan.logic as logic
@@ -14,11 +16,18 @@ import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
 import ckan.logic.schema as schema
 from ckan.lib.search.common import SearchError
+from pyfakefs import fake_filesystem
+
+from ckan.lib import uploader as ckan_uploader
 
 
 eq = nose.tools.eq_
 ok = nose.tools.ok_
 assert_raises = nose.tools.assert_raises
+
+fs = fake_filesystem.FakeFilesystem()
+fake_os = fake_filesystem.FakeOsModule(fs)
+fake_open = fake_filesystem.FakeFileOpen(fs)
 
 
 class TestPackageShow(helpers.FunctionalTestBase):
@@ -1742,7 +1751,51 @@ class TestShowResourceView(object):
             helpers.call_action, 'resource_view_show', id='does_not_exist')
 
 
+def mock_open_if_open_fails(*args, **kwargs):
+    try:
+        return real_open(*args, **kwargs)
+    except (OSError, IOError):
+        return fake_open(*args, **kwargs)
+
+
 class ShowResourceFileMetadata(object):
+
+    @helpers.change_config('ckan.storage_path', '/doesnt_exist')
+    @mock.patch.object(builtins, 'open', side_effect=mock_open_if_open_fails)
+    @mock.patch.object(ckan_uploader, 'os', fake_os)
+    @mock.patch.object(ckan_uploader, '_storage_path', new='/doesnt_exist')
+    def test_rresource_file_metadata_show_meta_data_returned(self, _):
+        user = factories.User()
+        pkg = factories.Dataset(creator_user_id=user['id'])
+        # upload_content = StringIO()
+        # upload_content.write('test-content')
+
+        url = url_for(
+            controller='api',
+            action='action',
+            logic_function='resource_create', ver='/3')
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        postparams = {
+            'name': 'test-flask-upload',
+            'package_id': pkg['id']
+        }
+        upload_content = 'test-content,and2'
+        upload_info = ('upload', 'test-upload.csv', upload_content)
+        app = self._get_test_app()
+        resp = app.post(
+            url, params=postparams,
+            upload_files=[upload_info],
+            extra_environ=env
+            # content_type= 'application/json'
+        )
+        result = resp.json['result']
+        eq('upload', result['url_type'])
+        eq(len(upload_content), result['size'])
+
+        metaresult = helpers.call_action('resource_file_metadata_show', id=result['id'])
+        eq(len(upload_content), metaresult['size'])
+        eq('text/csv', metaresult['content_type'])
+        eq('', metaresult['hash'])
 
     def test_resource_file_metadata_show_id_missing(self):
 

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1741,6 +1741,30 @@ class TestShowResourceView(object):
             logic.NotFound,
             helpers.call_action, 'resource_view_show', id='does_not_exist')
 
+class ShowResourceFileMetadata(object):
+
+    @classmethod
+    def setup_class(cls):
+        if not p.plugin_loaded('image_view'):
+            p.load('image_view')
+
+        helpers.reset_db()
+
+    @classmethod
+    def teardown_class(cls):
+        p.unload('image_view')
+
+    def test_resource_file_metadata_show_id_missing(self):
+
+        nose.tools.assert_raises(
+            logic.ValidationError,
+            helpers.call_action, 'resource_file_metadata_show')
+
+    def test_resource_file_metadata_show_id_not_found(self):
+
+        nose.tools.assert_raises(
+            logic.NotFound,
+            helpers.call_action, 'resource_file_metadata_show', id='does_not_exist')
 
 class TestGetHelpShow(object):
 

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1764,11 +1764,9 @@ class ShowResourceFileMetadata(object):
     @mock.patch.object(builtins, 'open', side_effect=mock_open_if_open_fails)
     @mock.patch.object(ckan_uploader, 'os', fake_os)
     @mock.patch.object(ckan_uploader, '_storage_path', new='/doesnt_exist')
-    def test_rresource_file_metadata_show_meta_data_returned(self, _):
+    def test_resource_file_metadata_show_meta_data_returned(self, _):
         user = factories.User()
         pkg = factories.Dataset(creator_user_id=user['id'])
-        # upload_content = StringIO()
-        # upload_content.write('test-content')
 
         url = url_for(
             controller='api',
@@ -1786,7 +1784,6 @@ class ShowResourceFileMetadata(object):
             url, params=postparams,
             upload_files=[upload_info],
             extra_environ=env
-            # content_type= 'application/json'
         )
         result = resp.json['result']
         eq('upload', result['url_type'])

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1741,18 +1741,8 @@ class TestShowResourceView(object):
             logic.NotFound,
             helpers.call_action, 'resource_view_show', id='does_not_exist')
 
+
 class ShowResourceFileMetadata(object):
-
-    @classmethod
-    def setup_class(cls):
-        if not p.plugin_loaded('image_view'):
-            p.load('image_view')
-
-        helpers.reset_db()
-
-    @classmethod
-    def teardown_class(cls):
-        p.unload('image_view')
 
     def test_resource_file_metadata_show_id_missing(self):
 
@@ -1765,6 +1755,7 @@ class ShowResourceFileMetadata(object):
         nose.tools.assert_raises(
             logic.NotFound,
             helpers.call_action, 'resource_file_metadata_show', id='does_not_exist')
+
 
 class TestGetHelpShow(object):
 


### PR DESCRIPTION
Adds Metadata api for uploaded files, returns; content type, hash, size of file

adds api get to surface data.


### Features:

- [X] includes tests covering changes
- [X] includes updated documentation
- [X] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
