### PR TITLE
[QOL-7841] make SQL function whitelist case-insensitive

### DIFF
--- a/ckan/tests/legacy/test_coding_standards.py
+++ b/ckan/tests/legacy/test_coding_standards.py
@@ -600,7 +600,6 @@ class TestPep8(object):
         'ckanext/datastore/bin/datastore_setup.py',
         'ckanext/datastore/logic/action.py',
         'ckanext/datastore/tests/test_create.py',
-        'ckanext/datastore/tests/test_search.py',
         'ckanext/datastore/tests/test_upsert.py',
         'ckanext/example_idatasetform/plugin.py',
         'ckanext/example_itemplatehelpers/plugin.py',

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1448,7 +1448,7 @@ def upsert(context, data_dict):
                 'query': ['Query took too long']
             })
         raise
-    except Exception as e:
+    except Exception:
         trans.rollback()
         raise
     finally:
@@ -1652,7 +1652,8 @@ class DatastorePostgresqlBackend(DatastoreBackend):
             )
 
             with open(allowed_sql_functions_file, 'r') as f:
-                self.allowed_sql_functions = set(line.strip().lower() for line in f)
+                self.allowed_sql_functions = set(line.strip().lower()
+                                                 for line in f)
 
         # Check whether we are running one of the paster commands which means
         # that we should ignore the following tests.
@@ -1828,7 +1829,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
                     'query': ['Query took too long']
                 })
             raise
-        except Exception as e:
+        except Exception:
             trans.rollback()
             raise
         finally:

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1511,7 +1511,10 @@ def search_sql(context, data_dict):
         context['check_access'](table_names)
 
         for f in function_names:
-            if f.lower() not in backend.allowed_sql_functions:
+            for name_variant in [f, f.lower(), '"{}"'.format(f)]:
+                if name_variant in backend.allowed_sql_functions:
+                    break
+            else:
                 raise toolkit.NotAuthorized({
                     'permissions': [
                         'Not authorized to call function {}'.format(f)]
@@ -1651,8 +1654,20 @@ class DatastorePostgresqlBackend(DatastoreBackend):
                 _SQL_FUNCTIONS_ALLOWLIST_FILE
             )
 
+            def format_entry(line):
+                '''Prepare an entry from the 'allowed_functions' file
+                to be used in the whitelist.
+
+                Leading and trailing whitespace is removed, and the
+                entry is lowercased unless enclosed in "double quotes".
+                '''
+                entry = line.strip()
+                if not entry.startswith('"'):
+                    entry = entry.lower()
+                return entry
+
             with open(allowed_sql_functions_file, 'r') as f:
-                self.allowed_sql_functions = set(line.strip().lower()
+                self.allowed_sql_functions = set(format_entry(line)
                                                  for line in f)
 
         # Check whether we are running one of the paster commands which means

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1511,7 +1511,7 @@ def search_sql(context, data_dict):
         context['check_access'](table_names)
 
         for f in function_names:
-            if f not in backend.allowed_sql_functions:
+            if f.lower() not in backend.allowed_sql_functions:
                 raise toolkit.NotAuthorized({
                     'permissions': [
                         'Not authorized to call function {}'.format(f)]
@@ -1652,7 +1652,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
             )
 
             with open(allowed_sql_functions_file, 'r') as f:
-                self.allowed_sql_functions = set(line.strip() for line in f)
+                self.allowed_sql_functions = set(line.strip().lower() for line in f)
 
         # Check whether we are running one of the paster commands which means
         # that we should ignore the following tests.

--- a/ckanext/datastore/tests/allowed_functions.txt
+++ b/ckanext/datastore/tests/allowed_functions.txt
@@ -1,2 +1,2 @@
 upper
-"unit_test"
+"count"

--- a/ckanext/datastore/tests/allowed_functions.txt
+++ b/ckanext/datastore/tests/allowed_functions.txt
@@ -1,0 +1,2 @@
+upper
+"unit_test"

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -857,6 +857,20 @@ class TestDatastoreSQL(DatastoreLegacyTestBase):
         )
         helpers.call_action("datastore_search_sql", sql=sql)
 
+    def test_allowed_functions_are_case_insensitive(self):
+        resource = factories.Resource()
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "records": [{"author": "bob"}, {"author": "jane"}],
+        }
+        helpers.call_action("datastore_create", **data)
+
+        sql = 'SELECT UpPeR(author) from "{}"'.format(
+            resource["id"]
+        )
+        helpers.call_action("datastore_search_sql", sql=sql)
+
     def test_not_authorized_with_disallowed_functions(self):
         resource = factories.Resource()
         data = {

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -870,6 +870,26 @@ class TestDatastoreSQL(DatastoreLegacyTestBase):
         )
         helpers.call_action("datastore_search_sql", sql=sql)
 
+    def test_quoted_allowed_functions_are_case_sensitive(self):
+        resource = factories.Resource()
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "records": [{"author": "bob"}, {"author": "jane"}],
+        }
+        helpers.call_action("datastore_create", **data)
+
+        sql = 'SELECT unit_test(author) from "{}"'.format(
+            resource["id"]
+        )
+        helpers.call_action("datastore_search_sql", sql=sql)
+
+        sql = 'SELECT UnIt_TeSt(author) from "{}"'.format(
+            resource["id"]
+        )
+        assert_raises(p.toolkit.NotAuthorized,
+                      helpers.call_action, "datastore_search_sql", sql=sql)
+
     def test_not_authorized_with_disallowed_functions(self):
         resource = factories.Resource()
         data = {

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -879,12 +879,12 @@ class TestDatastoreSQL(DatastoreLegacyTestBase):
         }
         helpers.call_action("datastore_create", **data)
 
-        sql = 'SELECT unit_test(author) from "{}"'.format(
+        sql = 'SELECT count(*) from "{}"'.format(
             resource["id"]
         )
         helpers.call_action("datastore_search_sql", sql=sql)
 
-        sql = 'SELECT UnIt_TeSt(author) from "{}"'.format(
+        sql = 'SELECT CoUnT(*) from "{}"'.format(
             resource["id"]
         )
         assert_raises(p.toolkit.NotAuthorized,

--- a/test-core.ini
+++ b/test-core.ini
@@ -21,6 +21,8 @@ sqlalchemy.url = postgresql://ckan_default:pass@localhost/ckan_test
 ckan.datastore.write_url = postgresql://ckan_default:pass@localhost/datastore_test
 ckan.datastore.read_url = postgresql://datastore_default:pass@localhost/datastore_test
 
+ckan.datastore.sqlsearch.allowed_functions_file = %(here)s/ckanext/datastore/tests/allowed_functions.txt
+
 ckan.datapusher.url = http://datapusher.ckan.org/
 ckan.datapusher.formats = csv xls xlsx tsv application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
 


### PR DESCRIPTION
### Proposed fixes:

Make SQL function whitelist case-insensitive since functions are normally called in a case-insensitive manner, unless the whitelist entry is enclosed in double quotes.

Eg if the whitelist file contains:

    count
    MAX
    "min"

then it will allow `count`, `COUNT`, `CoUnT`, `max`, `MAX`, `mAx`, and `min`, but not `MIN` or `MiN`.

### Features:

- [X] includes tests covering changes

Please [X] all the boxes above that apply
