### PR TITLE
[QOL-7939] allow post-reset landing page to be configured

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -555,7 +555,8 @@ class UserController(base.BaseController):
                 mailer.create_reset_key(user_obj)
 
                 h.flash_success(_("Your password has been reset."))
-                h.redirect_to(config.get('ckan.user_reset_landing_page', u'home.index'))
+                h.redirect_to(config.get(
+                    'ckan.user_reset_landing_page', u'home.index'))
             except NotAuthorized:
                 h.flash_error(_('Unauthorized to edit user %s') % id)
             except NotFound as e:

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -504,13 +504,16 @@ class UserController(base.BaseController):
                           'or contact an administrator for help')
                     )
                     log.exception(e)
-                    return h.redirect_to(u'/')
+                    return h.redirect_to(config.get(
+                        'ckan.user_reset_landing_page',
+                        u'home.index'))
             # always tell the user it succeeded, because otherwise we reveal
             # which accounts exist or not
             h.flash_success(
                 _(u'A reset link has been emailed to you '
                   '(unless the account specified does not exist)'))
-            return h.redirect_to(u'/')
+            return h.redirect_to(config.get(
+                'ckan.user_reset_landing_page', u'home.index'))
         return render('user/request_reset.html')
 
     def perform_reset(self, id):
@@ -552,7 +555,7 @@ class UserController(base.BaseController):
                 mailer.create_reset_key(user_obj)
 
                 h.flash_success(_("Your password has been reset."))
-                h.redirect_to(u'home.index')
+                h.redirect_to(config.get('ckan.user_reset_landing_page', u'home.index'))
             except NotAuthorized:
                 h.flash_error(_('Unauthorized to edit user %s') % id)
             except NotFound as e:

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -566,14 +566,16 @@ class RequestResetView(MethodView):
                 h.flash_error(_(u'Error sending the email. Try again later '
                                 'or contact an administrator for help'))
                 log.exception(e)
-                return h.redirect_to(u'/')
+                return h.redirect_to(config.get(
+                    'ckan.user_reset_landing_page', u'home.index'))
 
         # always tell the user it succeeded, because otherwise we reveal
         # which accounts exist or not
         h.flash_success(
             _(u'A reset link has been emailed to you '
               '(unless the account specified does not exist)'))
-        return h.redirect_to(u'/')
+        return h.redirect_to(config.get(
+            'ckan.user_reset_landing_page', u'home.index'))
 
     def get(self):
         self._prepare()
@@ -641,7 +643,8 @@ class PerformResetView(MethodView):
             mailer.create_reset_key(context[u'user_obj'])
 
             h.flash_success(_(u'Your password has been reset.'))
-            return h.redirect_to(u'home.index')
+            return h.redirect_to(config.get(
+                'ckan.user_reset_landing_page', u'home.index'))
         except logic.NotAuthorized:
             h.flash_error(_(u'Unauthorized to edit user %s') % id)
         except logic.NotFound:

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -567,7 +567,7 @@ class RequestResetView(MethodView):
                                 'or contact an administrator for help'))
                 log.exception(e)
                 return h.redirect_to(config.get(
-                    'ckan.user_reset_landing_page', u'home.index'))
+                    u'ckan.user_reset_landing_page', u'home.index'))
 
         # always tell the user it succeeded, because otherwise we reveal
         # which accounts exist or not
@@ -575,7 +575,7 @@ class RequestResetView(MethodView):
             _(u'A reset link has been emailed to you '
               '(unless the account specified does not exist)'))
         return h.redirect_to(config.get(
-            'ckan.user_reset_landing_page', u'home.index'))
+            u'ckan.user_reset_landing_page', u'home.index'))
 
     def get(self):
         self._prepare()
@@ -644,7 +644,7 @@ class PerformResetView(MethodView):
 
             h.flash_success(_(u'Your password has been reset.'))
             return h.redirect_to(config.get(
-                'ckan.user_reset_landing_page', u'home.index'))
+                u'ckan.user_reset_landing_page', u'home.index'))
         except logic.NotAuthorized:
             h.flash_error(_(u'Unauthorized to edit user %s') % id)
         except logic.NotFound:


### PR DESCRIPTION
- This is useful when the homepage is externally hosted and cannot display CKAN's flash messages;
it's now possible to send the user somewhere else, like the dataset search page.

### Features:

- [X] includes user-visible changes
