### PR TITLE
[DC-19474] update sqlparse to handle CSV headers containing line breaks and semicolons

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ rq==0.6.0
 simplejson==3.10.0
 sqlalchemy-migrate==0.10.0
 SQLAlchemy==1.1.18
-sqlparse==0.2.2
+sqlparse==0.3.1
 tzlocal==1.3
 unicodecsv>=0.9
 vdm==0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -135,7 +135,7 @@ sqlalchemy==1.1.18
     # via
     #   -r requirements.in
     #   sqlalchemy-migrate
-sqlparse==0.2.2
+sqlparse==0.3.1
     # via
     #   -r requirements.in
     #   sqlalchemy-migrate


### PR DESCRIPTION
This was patched before but appears to be have overlooked when moving to 2.8.7.