### PR TITLE
[DC-22863] fix logging to use instance instead of module and correct number of format markers

### DIFF
--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -255,7 +255,7 @@ class Upload(object):
             hash, length = _file_hashnlength(filepath)
             return {'content_type': content_type, 'size': length, 'hash': hash}
         except IOError as e:
-            logging.error("Could not retrieve meta data,  IOError thrown", e)
+            log.error("Could not retrieve meta data, IOError thrown: %s", e)
             return e
 
 
@@ -409,5 +409,5 @@ class ResourceUpload(object):
             hash, length = _file_hashnlength(filepath)
             return {'content_type': content_type, 'size': length, 'hash': hash}
         except IOError as e:
-            logging.error("Could not retrieve meta data,  IOError thrown", e)
+            log.error("Could not retrieve meta data, IOError thrown: %s", e)
             return e


### PR DESCRIPTION
This is causing errors on the Archiver, with 404 errors on resources disrupting the archival of the entire dataset.