### PR TITLE
[QOL-7905] ignore auth on user API when performing a password reset, #6777

### DIFF
--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -480,7 +480,7 @@ def i18n_js_translations(lang, ver=API_REST_DEFAULT_VERSION):
                              u'base', u'i18n', u'{0}.js'.format(lang)))
     if not os.path.exists(source):
         return u'{}'
-    translations = json.load(io.open(source, u'r', encoding='utf-8'))
+    translations = json.load(io.open(source, u'r', encoding=u'utf-8'))
     return _finish_ok(translations)
 
 

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -692,10 +692,12 @@ class PerformResetView(MethodView):
         except logic.NotAuthorized:
             base.abort(403, _(u'Unauthorized to reset password.'))
 
+        context[u'ignore_auth'] = True
         try:
             user_dict = logic.get_action(u'user_show')(context, {u'id': id})
         except logic.NotFound:
             base.abort(404, _(u'User not found'))
+        del context[u'ignore_auth']
         user_obj = context[u'user_obj']
         g.reset_key = request.params.get(u'key')
         if not mailer.verify_reset_link(user_obj, g.reset_key):


### PR DESCRIPTION
We verify the user via token without them logging in. This is not relevant in the default configuration,
but becomes necessary if 'ckan.auth.public_user_details' is set

Fixes #6777

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport
