### PR TITLE
Cherry-pick upstream fix

### DIFF
--- a/changes/6698.bugfix
+++ b/changes/6698.bugfix
@@ -1,1 +1,0 @@
-Ensure that locale exists on i18n JS API

--- a/ckan/lib/i18n.py
+++ b/ckan/lib/i18n.py
@@ -76,7 +76,7 @@ _JS_TRANSLATIONS_DIR = os.path.join(_CKAN_DIR, u'public', u'base', u'i18n')
 
 def get_ckan_i18n_dir():
     path = config.get(
-        u'ckan.i18n_directory', os.path.join(_CKAN_DIR, u'i18n'))
+        u'ckan.i18n_directory') or os.path.join(_CKAN_DIR, u'i18n')
     if os.path.isdir(os.path.join(path, u'i18n')):
         path = os.path.join(path, u'i18n')
 

--- a/ckan/tests/controllers/test_api.py
+++ b/ckan/tests/controllers/test_api.py
@@ -273,14 +273,3 @@ class TestApiController(object):
         assert sorted(res_dict["result"]) == sorted(
             [dataset1["name"], dataset2["name"]]
         )
-
-
-def test_i18n_only_known_locales_are_accepted(app):
-
-    url = url_for("api.i18n_js_translations", ver=2, lang="fr")
-
-    assert app.get(url).status_code == 200
-
-    url = url_for("api.i18n_js_translations", ver=2, lang="unknown_lang")
-    r = app.get(url, status=400)
-    assert "Bad request - Unknown locale" in r.get_data(as_text=True)

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -14,7 +14,6 @@ import ckan.model as model
 from ckan.common import json, _, g, request
 from ckan.lib.helpers import url_for
 from ckan.lib.base import render
-from ckan.lib.i18n import get_locales_from_config
 
 from ckan.lib.navl.dictization_functions import DataError
 from ckan.logic import get_action, ValidationError, NotFound, NotAuthorized
@@ -476,10 +475,6 @@ def snippet(snippet_path, ver=API_REST_DEFAULT_VERSION):
 
 
 def i18n_js_translations(lang, ver=API_REST_DEFAULT_VERSION):
-
-    if lang not in get_locales_from_config():
-        return _finish_bad_request('Unknown locale: {}'.format(lang))
-
     ckan_path = os.path.join(os.path.dirname(__file__), u'..')
     source = os.path.abspath(os.path.join(ckan_path, u'public',
                              u'base', u'i18n', u'{0}.js'.format(lang)))

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -478,7 +478,7 @@ def snippet(snippet_path, ver=API_REST_DEFAULT_VERSION):
 def i18n_js_translations(lang, ver=API_REST_DEFAULT_VERSION):
 
     if lang not in get_locales_from_config():
-        return _finish_bad_request(u'Unknown locale: {}'.format(lang))
+        return _finish_bad_request('Unknown locale: {}'.format(lang))
 
     ckan_path = os.path.join(os.path.dirname(__file__), u'..')
     source = os.path.abspath(os.path.join(ckan_path, u'public',


### PR DESCRIPTION
The locale changes from the dev-v2.9 branch break our tests, so reverting them but keeping others.