### PR TITLE
[DC-32816] update sqlparse to handle CSV contents more robustly

### DIFF
--- a/requirements-py2.in
+++ b/requirements-py2.in
@@ -35,7 +35,7 @@ rq==1.0
 simplejson==3.10.0
 sqlalchemy-migrate==0.12.0
 SQLAlchemy==1.3.5
-sqlparse==0.2.2
+sqlparse==0.3.1
 tzlocal==1.3
 unicodecsv>=0.9
 webassets==0.12.1

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -59,7 +59,7 @@ simplejson==3.10.0
 six==1.12.0               # via bleach, pastescript, python-dateutil, pyutilib.component.core, sqlalchemy-migrate
 sqlalchemy-migrate==0.12.0
 sqlalchemy==1.3.5
-sqlparse==0.2.2
+sqlparse==0.3.1
 tempita==0.5.2            # via pylons, sqlalchemy-migrate, weberror
 tzlocal==1.3
 unicodecsv==0.14.1

--- a/requirements.in
+++ b/requirements.in
@@ -29,7 +29,7 @@ Routes==1.13
 rq==1.0
 simplejson==3.10.0
 SQLAlchemy==1.3.5
-sqlparse==0.2.2
+sqlparse==0.4.2
 tzlocal==1.3
 unicodecsv>=0.9
 watchdog==2.1.5         # For py3 support

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ shutilwhich==1.1.0        # via fanstatic
 simplejson==3.10.0        # via -r requirements.in
 six==1.16.0               # via bleach, python-dateutil, pyutilib
 sqlalchemy==1.3.5         # via -r requirements.in, alembic
-sqlparse==0.2.2           # via -r requirements.in
+sqlparse==0.4.2           # via -r requirements.in
 tzlocal==1.3              # via -r requirements.in
 unicodecsv==0.14.1        # via -r requirements.in
 urllib3==1.26.6           # via requests


### PR DESCRIPTION
This is already fixed on master but not backported to 2.9.

Fixes #5822

### Proposed fixes:

- Update `sqlparse` to 0.3.1 (Py2) or 0.4.2 (Py3) to fix handling of semicolons in CSV headers.