### PR TITLE
[QOL-9275] add config flag to control private dataset behaviour

### DIFF
--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -641,7 +641,7 @@ class TestPackageRead(object):
             assert "Test Dataset" in response.body
             assert "Just another test dataset" in response.body
 
-    def test_anonymous_users_cannot_read_private_datasets(self, app):
+    def test_anonymous_users_cannot_see_private_datasets(self, app):
         organization = factories.Organization()
         dataset = factories.Dataset(owner_org=organization["id"], private=True)
         response = app.get(
@@ -649,7 +649,7 @@ class TestPackageRead(object):
         )
         assert 404 == response.status_code
 
-    def test_user_not_in_organization_cannot_read_private_datasets(self, app):
+    def test_user_not_in_organization_cannot_see_private_datasets(self, app):
         user = factories.User()
         organization = factories.Organization()
         dataset = factories.Dataset(owner_org=organization["id"], private=True)
@@ -751,6 +751,31 @@ class TestPackageRead(object):
             extra_environ=env,
             status=404,
         )
+
+    # Test the 'reveal_private_datasets' flag
+
+    @pytest.mark.ckan_config("ckan.auth.reveal_private_datasets", "True")
+    def test_anonymous_users_cannot_read_private_datasets(self, app):
+        organization = factories.Organization()
+        dataset = factories.Dataset(owner_org=organization["id"], private=True)
+        response = app.get(
+            url_for("dataset.read", id=dataset["name"]),
+            follow_redirects=False
+        )
+        assert 302 == response.status_code
+        assert '/login' in response.headers[u"Location"]
+
+    @pytest.mark.ckan_config("ckan.auth.reveal_private_datasets", "True")
+    def test_user_not_in_organization_cannot_read_private_datasets(self, app):
+        user = factories.User()
+        organization = factories.Organization()
+        dataset = factories.Dataset(owner_org=organization["id"], private=True)
+        response = app.get(
+            url_for("dataset.read", id=dataset["name"]),
+            extra_environ={"REMOTE_USER": six.ensure_str(user["name"])},
+            status=403,
+        )
+        assert 403 == response.status_code
 
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")
@@ -1255,7 +1280,7 @@ class TestResourceRead(object):
 
         app.get(url, status=200, extra_environ=env)
 
-    def test_user_not_in_organization_cannot_read_private_dataset(self, app):
+    def test_user_not_in_organization_cannot_see_resources_in_private_dataset(self, app):
         user = factories.User()
         env = {"REMOTE_USER": six.ensure_str(user["name"])}
         organization = factories.Organization()
@@ -1301,13 +1326,44 @@ class TestResourceRead(object):
             )
             assert "Just another test resource" in response.body
 
-    def test_anonymous_users_cannot_read_private_datasets(self, app):
+    def test_anonymous_users_cannot_see_resources_in_private_datasets(self, app):
         organization = factories.Organization()
         dataset = factories.Dataset(owner_org=organization["id"], private=True)
+        resource = factories.Resource(package_id=dataset["id"])
         response = app.get(
             url_for("dataset.read", id=dataset["name"]), status=404
         )
         assert 404 == response.status_code
+
+    # Test the 'reveal_private_datasets' flag
+
+    @pytest.mark.ckan_config("ckan.auth.reveal_private_datasets", "True")
+    def test_user_not_in_organization_cannot_read_resources_in_private_dataset(self, app):
+        user = factories.User()
+        env = {"REMOTE_USER": six.ensure_str(user["name"])}
+        organization = factories.Organization()
+        dataset = factories.Dataset(owner_org=organization["id"], private=True)
+        resource = factories.Resource(package_id=dataset["id"])
+
+        url = url_for(
+            "{}_resource.read".format(dataset["type"]),
+            id=dataset["id"], resource_id=resource["id"]
+        )
+
+        response = app.get(url, status=403, extra_environ=env)
+
+    @pytest.mark.ckan_config("ckan.auth.reveal_private_datasets", "True")
+    def test_anonymous_users_cannot_read_resources_in_private_datasets(self, app):
+        organization = factories.Organization()
+        dataset = factories.Dataset(owner_org=organization["id"], private=True)
+        resource = factories.Resource(package_id=dataset["id"])
+        response = app.get(
+            url_for("{}_resource.read".format(dataset["type"]),
+                    id=dataset["id"], resource_id=resource["id"]),
+            follow_redirects=False
+        )
+        assert 302 == response.status_code
+        assert '/login' in response.headers[u"Location"]
 
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from flask import Blueprint
 from flask.views import MethodView
 from werkzeug.datastructures import MultiDict
-from ckan.common import asbool
 
 import six
 from six import string_types, text_type
@@ -20,7 +19,7 @@ import ckan.logic as logic
 import ckan.model as model
 import ckan.plugins as plugins
 import ckan.authz as authz
-from ckan.common import _, config, g, request
+from ckan.common import _, asbool, config, g, request
 from ckan.views.home import CACHE_PARAMETERS
 from ckan.lib.plugins import lookup_package_plugin
 from ckan.lib.render import TemplateNotFound
@@ -434,7 +433,21 @@ def read(package_type, id):
     try:
         pkg_dict = get_action(u'package_show')(context, data_dict)
         pkg = context[u'package']
-    except (NotFound, NotAuthorized):
+    except NotFound:
+        return base.abort(
+            404,
+            _(u'Dataset not found')
+        )
+    except NotAuthorized:
+        if asbool(config.get(u'ckan.auth.reveal_private_datasets')):
+            if context['user']:
+                return base.abort(
+                    403, _(u'Unauthorized to read package %s') % id)
+            else:
+                return h.redirect_to(
+                    u'user.login',
+                    came_from=h.url_for(u'{}.read'.format(package_type), id=id)
+                )
         return base.abort(404, _(u'Dataset not found'))
 
     g.pkg_dict = pkg_dict

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -15,7 +15,7 @@ import ckan.lib.uploader as uploader
 import ckan.logic as logic
 import ckan.model as model
 import ckan.plugins as plugins
-from ckan.common import _, g, request
+from ckan.common import _, asbool, config, g, request
 from ckan.views.home import CACHE_PARAMETERS
 from ckan.views.dataset import (
     _get_pkg_template, _get_package_type, _setup_template_variables
@@ -59,7 +59,23 @@ def read(package_type, id, resource_id):
 
     try:
         package = get_action(u'package_show')(context, {u'id': id})
-    except (NotFound, NotAuthorized):
+    except NotFound:
+        return base.abort(
+            404,
+            _(u'Dataset not found')
+        )
+    except NotAuthorized:
+        if asbool(config.get(u'ckan.auth.reveal_private_datasets')):
+            if context['user']:
+                return base.abort(
+                    403, _(u'Unauthorized to read resource %s') % resource_id)
+            else:
+                return h.redirect_to(
+                    u'user.login',
+                    came_from=h.url_for(
+                        u'{}_resource.read'.format(package_type),
+                        id=id, resource_id=resource_id)
+                )
         return base.abort(404, _(u'Dataset not found'))
     activity_id = request.params.get(u'activity_id')
     if activity_id:


### PR DESCRIPTION
If set to True, then return Forbidden or redirect to login page, instead of hiding the dataset's existence.
