### PR TITLE
[QOLSVC-492] REPLACED - Let trash links use the base /dataset type instead of custom types

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -291,60 +291,6 @@ def _get_auto_flask_context():
 
 @core_helper
 def url_for(*args, **kw):
-    '''Return the URL for an endpoint given some parameters, defaulting to
-    using 'dataset' if the given custom dataset fails.
-
-    This is a wrapper for :py:func:`flask.url_for`
-    and :py:func:`routes.url_for` that adds some extra features that CKAN
-    needs.
-
-    To build a URL for a Flask view, pass the name of the blueprint and the
-    view function separated by a period ``.``, plus any URL parameters::
-
-        url_for('api.action', ver=3, logic_function='status_show')
-        # Returns /api/3/action/status_show
-
-    For a fully qualified URL pass the ``_external=True`` parameter. This
-    takes the ``ckan.site_url`` and ``ckan.root_path`` settings into account::
-
-        url_for('api.action', ver=3, logic_function='status_show',
-                _external=True)
-        # Returns http://example.com/api/3/action/status_show
-
-    URLs built by Pylons use the Routes syntax::
-
-        url_for(controller='my_ctrl', action='my_action', id='my_dataset')
-        # Returns '/dataset/my_dataset'
-
-    Or, using a named route::
-
-        url_for('dataset.read', id='changed')
-        # Returns '/dataset/changed'
-
-    Use ``qualified=True`` for a fully qualified URL when targeting a Pylons
-    endpoint.
-
-    For backwards compatibility, an effort is made to support the Pylons syntax
-    when building a Flask URL, but this support might be dropped in the future,
-    so calls should be updated.
-    '''
-    try:
-        return base_url_for(*args, **kw)
-    except FlaskRouteBuildError:
-        # If the url failed, try again but replace the custom dataset type with the default 'dataset'
-        if (len(args) and '.' in args[0]
-                and not args[0].startswith('/')):
-            args = (args[0].split('.', 1),)
-            args = 'dataset.' + args[1]
-
-        if kw.get('controller'):
-            kw.update({'controller': 'dataset'})
-
-        return base_url_for(*args, **kw)
-
-
-@core_helper
-def base_url_for(*args, **kw):
     '''Return the URL for an endpoint given some parameters.
 
     This is a wrapper for :py:func:`flask.url_for`

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -290,6 +290,18 @@ def _get_auto_flask_context():
 
 
 @core_helper
+def default_url_for(package_type, **kw):
+    '''Return the URL for an endpoint given some parameters, or use the default '/dataset' url if unable.
+
+    This is a wrapper for :py:func:`url_for` that defaults to using 'dataset.read' should the original arguments fail
+    '''
+    try:
+        url_for('{0}.read'.format(package_type), **kw)
+    except FlaskRouteBuildError:
+        return url_for('dataset.read', **kw)
+
+
+@core_helper
 def url_for(*args, **kw):
     '''Return the URL for an endpoint given some parameters.
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -290,19 +290,61 @@ def _get_auto_flask_context():
 
 
 @core_helper
-def default_url_for(package_type, **kw):
-    '''Return the URL for an endpoint given some parameters, or use the default '/dataset' url if unable.
+def url_for(*args, **kw):
+    '''Return the URL for an endpoint given some parameters, defaulting to
+    using 'dataset' if the given custom dataset fails.
 
-    This is a wrapper for :py:func:`url_for` that defaults to using 'dataset.read' should the original arguments fail
+    This is a wrapper for :py:func:`flask.url_for`
+    and :py:func:`routes.url_for` that adds some extra features that CKAN
+    needs.
+
+    To build a URL for a Flask view, pass the name of the blueprint and the
+    view function separated by a period ``.``, plus any URL parameters::
+
+        url_for('api.action', ver=3, logic_function='status_show')
+        # Returns /api/3/action/status_show
+
+    For a fully qualified URL pass the ``_external=True`` parameter. This
+    takes the ``ckan.site_url`` and ``ckan.root_path`` settings into account::
+
+        url_for('api.action', ver=3, logic_function='status_show',
+                _external=True)
+        # Returns http://example.com/api/3/action/status_show
+
+    URLs built by Pylons use the Routes syntax::
+
+        url_for(controller='my_ctrl', action='my_action', id='my_dataset')
+        # Returns '/dataset/my_dataset'
+
+    Or, using a named route::
+
+        url_for('dataset.read', id='changed')
+        # Returns '/dataset/changed'
+
+    Use ``qualified=True`` for a fully qualified URL when targeting a Pylons
+    endpoint.
+
+    For backwards compatibility, an effort is made to support the Pylons syntax
+    when building a Flask URL, but this support might be dropped in the future,
+    so calls should be updated.
     '''
     try:
-        url_for('{0}.read'.format(package_type), **kw)
+        return base_url_for(*args, **kw)
     except FlaskRouteBuildError:
-        return url_for('dataset.read', **kw)
+        # If the url failed, try again but replace the custom dataset type with the default 'dataset'
+        if (len(args) and '.' in args[0]
+                and not args[0].startswith('/')):
+            args = (args[0].split('.', 1),)
+            args = 'dataset.' + args[1]
+
+        if kw.get('controller'):
+            kw.update({'controller': 'dataset'})
+
+        return base_url_for(*args, **kw)
 
 
 @core_helper
-def url_for(*args, **kw):
+def base_url_for(*args, **kw):
     '''Return the URL for an endpoint given some parameters.
 
     This is a wrapper for :py:func:`flask.url_for`

--- a/ckan/templates/admin/snippets/data_type.html
+++ b/ckan/templates/admin/snippets/data_type.html
@@ -20,7 +20,7 @@
     {% for entity in entities %}
       {% set title = entity.title or entity.name %}
         <li>
-          {{ h.link_to(h.truncate(title, truncate_title), h.url_for(entity.type + '.read', id=entity.name)) }}
+          {{ h.link_to(h.truncate(title, truncate_title), h.url_for('dataset.read', id=entity.name)) }}
         </li>
       {% else %}
       <p>
@@ -33,7 +33,7 @@
   {% if entities.first() %}
     <form method="POST" action="{{ h.url_for('admin.trash') }}" id="form-purge-{{ ent_type }}">
       <input type="hidden" name="action" value="{{ent_type}}">
-      <a href="{{ h.url_for('admin.trash', name=ent_type) }}" 
+      <a href="{{ h.url_for('admin.trash', name=ent_type) }}"
          class="btn btn-danger purge-all"
          data-module="confirm-action"
          data-module-with-data=true


### PR DESCRIPTION
This pull request with the fix is currently replaced by the pull request with the more general fix at https://github.com/qld-gov-au/ckan/pull/77

Not closing this out quite yet in case this fix is still required, e.g. if there are issues with the general fix