### PR TITLE
[QOLDEV-297] Modify the url_for function to use the default dataset if a custom one fails

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -338,7 +338,7 @@ def url_for(*args, **kw):
                 and not args[0].startswith('/')
                 and not args[0].startswith('dataset.')):
             args = args[0].split('.', 1)
-            args = 'dataset.' + args[1]
+            args = ('dataset.' + args[1],)
             retry_with_default = True
 
         # Update kw controller if a custom dataset type was set there

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1190,7 +1190,16 @@ def _make_menu_item(menu_item, title, **kw):
     menu_item = map_pylons_to_flask_route_name(menu_item)
     _menu_items = config['routes.named_routes']
     if menu_item not in _menu_items:
-        raise Exception('menu item `%s` cannot be found' % menu_item)
+        # Try with default dataset
+        if ('.' in menu_item
+                and not menu_item.startswith('/')
+                and not menu_item.startswith('dataset.')):
+            menu_item_default = 'dataset.' + menu_item.split('.', 1)[1]
+        else:
+            raise Exception('menu item `%s` cannot be found' % menu_item)
+        if menu_item_default not in _menu_items:
+            raise Exception('menu items `%s` and `%s` cannot be found' % (menu_item, menu_item_default))
+        menu_item = menu_item_default
     item = copy.copy(_menu_items[menu_item])
     item.update(kw)
     active = _link_active(item)

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -337,7 +337,7 @@ def url_for(*args, **kw):
         if (len(args) and '.' in args[0]
                 and not args[0].startswith('/')
                 and not args[0].startswith('dataset.')):
-            args = (args[0].split('.', 1),)
+            args = args[0].split('.', 1)
             args = 'dataset.' + args[1]
             retry_with_default = True
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -331,16 +331,26 @@ def url_for(*args, **kw):
     try:
         return base_url_for(*args, **kw)
     except FlaskRouteBuildError:
-        # If the url failed, try again but replace the custom dataset type with the default 'dataset'
+        # If the url failed, try again but replace any custom dataset type in use with the default 'dataset'
+        retry_with_default = False
+        # Update args if a custom dataset type was set there
         if (len(args) and '.' in args[0]
-                and not args[0].startswith('/')):
+                and not args[0].startswith('/')
+                and not args[0].startswith('dataset.')):
             args = (args[0].split('.', 1),)
             args = 'dataset.' + args[1]
+            retry_with_default = True
 
-        if kw.get('controller'):
+        # Update kw controller if a custom dataset type was set there
+        if (kw.get('controller')
+                and kw.get('controller') != 'dataset'):
             kw.update({'controller': 'dataset'})
+            retry_with_default = True
 
-        return base_url_for(*args, **kw)
+        if retry_with_default:
+            return base_url_for(*args, **kw)
+        else:
+            raise
 
 
 @core_helper

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -291,6 +291,60 @@ def _get_auto_flask_context():
 
 @core_helper
 def url_for(*args, **kw):
+    '''Return the URL for an endpoint given some parameters, defaulting to
+    using 'dataset' if the given custom dataset fails.
+
+    This is a wrapper for :py:func:`flask.url_for`
+    and :py:func:`routes.url_for` that adds some extra features that CKAN
+    needs.
+
+    To build a URL for a Flask view, pass the name of the blueprint and the
+    view function separated by a period ``.``, plus any URL parameters::
+        url_for('api.action', ver=3, logic_function='status_show')
+        # Returns /api/3/action/status_show
+
+    For a fully qualified URL pass the ``_external=True`` parameter. This
+    takes the ``ckan.site_url`` and ``ckan.root_path`` settings into account::
+
+        url_for('api.action', ver=3, logic_function='status_show',
+                _external=True)
+
+        # Returns http://example.com/api/3/action/status_show
+
+    URLs built by Pylons use the Routes syntax::
+
+        url_for(controller='my_ctrl', action='my_action', id='my_dataset')
+        # Returns '/dataset/my_dataset'
+
+    Or, using a named route::
+
+        url_for('dataset.read', id='changed')
+        # Returns '/dataset/changed'
+
+    Use ``qualified=True`` for a fully qualified URL when targeting a Pylons
+    endpoint.
+
+    For backwards compatibility, an effort is made to support the Pylons syntax
+    when building a Flask URL, but this support might be dropped in the future,
+    so calls should be updated.
+    '''
+    try:
+        return base_url_for(*args, **kw)
+    except FlaskRouteBuildError:
+        # If the url failed, try again but replace the custom dataset type with the default 'dataset'
+        if (len(args) and '.' in args[0]
+                and not args[0].startswith('/')):
+            args = (args[0].split('.', 1),)
+            args = 'dataset.' + args[1]
+
+        if kw.get('controller'):
+            kw.update({'controller': 'dataset'})
+
+        return base_url_for(*args, **kw)
+
+
+@core_helper
+def base_url_for(*args, **kw):
     '''Return the URL for an endpoint given some parameters.
 
     This is a wrapper for :py:func:`flask.url_for`

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -45,7 +45,6 @@ import ckan.authz as authz
 import ckan.plugins as p
 import ckan
 
-from ckan.lib.pagination import Page
 from ckan.common import _, ungettext, c, g, request, session, json
 from ckan.lib.webassets_tools import include_asset, render_assets
 from markupsafe import Markup, escape
@@ -331,7 +330,8 @@ def url_for(*args, **kw):
     try:
         return base_url_for(*args, **kw)
     except FlaskRouteBuildError:
-        # If the url failed, try again but replace any custom dataset type in use with the default 'dataset'
+        # If the url failed, try again but replace any custom dataset type in
+        #  use with the default 'dataset'
         retry_with_default = False
         # Update args if a custom dataset type was set there
         if (len(args) and '.' in args[0]
@@ -1198,7 +1198,8 @@ def _make_menu_item(menu_item, title, **kw):
         else:
             raise Exception('menu item `%s` cannot be found' % menu_item)
         if menu_item_default not in _menu_items:
-            raise Exception('menu items `%s` and `%s` cannot be found' % (menu_item, menu_item_default))
+            raise Exception('menu items `%s` and `%s` cannot be found'
+                            % (menu_item, menu_item_default))
         menu_item = menu_item_default
     item = copy.copy(_menu_items[menu_item])
     item.update(kw)


### PR DESCRIPTION
Copied from [[QOLSVC-492] Let trash links use the base /dataset type instead of custom types #72](https://github.com/qld-gov-au/ckan/pull/72)

[QOLSVC-492]: https://ssq-qol.atlassian.net/browse/QOLSVC-492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ