### PR TITLE
QOLDEV-367 prepare 2.10 fork

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,18 @@ Changelog
 
 .. towncrier release notes start
 
+v.2.10.x 2023-xx-xx
+==================
+
+Major features
+--------------
+
+- Update to Interface IUploader, on get_uploader and get_resource_uploader,
+  new to include new method signature metadata() which can be utilised by
+  archiver and other plugins instead of trying on local disk directly
+- Add get API `resource_file_metadata_show` which takes resource ID and returns
+  { 'content_type': content_type, 'size': length, 'hash': hash } if found
+
 v.2.10.0 2023-02-15
 ===================
 

--- a/ckan/i18n/en_AU/LC_MESSAGES/ckan.po
+++ b/ckan/i18n/en_AU/LC_MESSAGES/ckan.po
@@ -2,10 +2,10 @@
 # Copyright (C) 2022 ORGANIZATION
 # This file is distributed under the same license as the ckan project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
-# 
+#
 # Translators:
 # Adrià Mercader <adria.mercader@okfn.org>, 2022
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
@@ -3164,7 +3164,7 @@ msgstr "Change details"
 
 #: ckan/templates/user/edit_user_form.html:13
 msgid "Full name"
-msgstr "Full name"
+msgstr "Displayed name"
 
 #: ckan/templates/user/edit_user_form.html:13
 msgid "eg. Joe Bloggs"
@@ -3336,7 +3336,7 @@ msgstr "username"
 
 #: ckan/templates/user/new_user_form.html:11
 msgid "Full Name"
-msgstr "Full Name"
+msgstr "Displayed Name"
 
 #: ckan/templates/user/new_user_form.html:37
 msgid "Create Account"

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -14,10 +14,9 @@ from urllib.parse import urlparse
 
 from werkzeug.datastructures import FileStorage as FlaskFileStorage
 
-import ckan.lib.munge as munge
-import ckan.logic as logic
-import ckan.plugins as plugins
+from ckan import logic, plugins
 from ckan.common import config
+from ckan.lib import base, munge
 from ckan.types import ErrorDict, PUploader, PResourceUploader, Response
 
 ALLOWED_UPLOAD_TYPES = (cgi.FieldStorage, FlaskFileStorage)
@@ -115,7 +114,7 @@ def _file_hashnlength(local_path: str) -> tuple[str, int]:
 
 
 def _add_download_headers(file_path: str,
-                          mime_type: str,
+                          mime_type: Optional[str],
                           response: Response) -> None:
     """ Add appropriate 'Content-Type' and 'Content-Disposition' headers
     to a a file download.
@@ -150,15 +149,16 @@ class Upload(object):
         path = get_storage_path()
         if not path:
             return
-        self.storage_path = os.path.join(path, 'storage',
-                                         'uploads', object_type)
+        path = os.path.join(path, 'storage', 'uploads', object_type)
+        self.storage_path = path
+
         # check if the storage directory is already created by
         # the user or third-party
-        if os.path.isdir(self.storage_path):
+        if os.path.isdir(path):
             pass
         else:
             try:
-                os.makedirs(self.storage_path)
+                os.makedirs(path)
             except OSError as e:
                 # errno 17 is file already exists
                 if e.errno != 17:
@@ -166,7 +166,14 @@ class Upload(object):
         self.object_type = object_type
         self.old_filename = old_filename
         if old_filename:
-            self.old_filepath = os.path.join(self.storage_path, old_filename)
+            self.old_filepath = os.path.join(path, old_filename)
+
+    def _get_storage_path_for(self, filename: str) -> str:
+        '''Function to get the path to a stored file.
+        Storage path must be configured.
+        '''
+        assert self.storage_path
+        return os.path.join(self.storage_path or '', filename)
 
     def update_data_dict(self, data_dict: dict[str, Any], url_field: str,
                          file_field: str, clear_field: str) -> None:
@@ -193,7 +200,7 @@ class Upload(object):
                     self.filename = str(datetime.datetime.utcnow()) \
                         + self.filename
                 self.filename = munge.munge_filename_legacy(self.filename)
-                self.filepath = os.path.join(self.storage_path, self.filename)
+                self.filepath = self._get_storage_path_for(self.filename)
                 data_dict[url_field] = self.filename
                 self.upload_file = _get_underlying_file(
                     self.upload_field_storage)
@@ -261,26 +268,30 @@ class Upload(object):
 
     def delete(self, filename: str) -> None:
         ''' Delete file we are pointing at'''
-        if not filename.startswith('http'):
+        if self.storage_path and not filename.startswith('http'):
             try:
                 # Delete file from storage_path and filename
-                os.remove(os.path.join(self.storage_path, filename))
+                os.remove(self._get_storage_path_for(filename))
             except OSError:
                 pass
 
     def download(self, filename: str) -> Response:
         ''' Generate file stream or redirect for file'''
-        filepath = os.path.join(self.storage_path, filename)
+        if not self.storage_path:
+            return base.abort(404, "Uploaded resource not found")
+        filepath = self._get_storage_path_for(filename)
         resp = flask.send_file(filepath)
-        content_type, content_enc = mimetypes.guess_type(filepath)
+        content_type, _ = mimetypes.guess_type(filepath)
         _add_download_headers(filepath, content_type, resp)
         return resp
 
     def metadata(self, filename: str) -> Union[dict[str, Any], IOError]:
         ''' Return metadata of file'''
+        if not self.storage_path:
+            return {}
         try:
-            filepath = os.path.join(self.storage_path, filename)
-            content_type, content_encoding = mimetypes.guess_type(filepath)
+            filepath = self._get_storage_path_for(filename)
+            content_type, _ = mimetypes.guess_type(filepath)
             hash, length = _file_hashnlength(filepath)
             return {'content_type': content_type, 'size': length, 'hash': hash}
         except IOError as e:
@@ -290,6 +301,7 @@ class Upload(object):
 
 class ResourceUpload(object):
     mimetype: Optional[str]
+    url: Optional[str]
 
     def __init__(self, resource: dict[str, Any]) -> None:
         path = get_storage_path()
@@ -352,7 +364,7 @@ class ResourceUpload(object):
 
     def get_directory(self, id: str) -> str:
         assert self.storage_path
-        directory = os.path.join(self.storage_path,
+        directory = os.path.join(self.storage_path or '',
                                  id[0:3], id[3:6])
         return directory
 
@@ -437,8 +449,10 @@ class ResourceUpload(object):
             filepath = self.get_path(id)
             if self.mimetype:
                 content_type = self.mimetype
+            elif self.url:
+                content_type = mimetypes.guess_type(self.url or '')[0]
             else:
-                content_type = mimetypes.guess_type(self.url)[0]
+                raise IOError("No resource URL found")
             hash, length = _file_hashnlength(filepath)
             return {'content_type': content_type, 'size': length, 'hash': hash}
         except IOError as e:

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -1,6 +1,8 @@
 # encoding: utf-8
 from __future__ import annotations
 
+import flask
+import hashlib
 import os
 import cgi
 import datetime
@@ -16,7 +18,7 @@ import ckan.lib.munge as munge
 import ckan.logic as logic
 import ckan.plugins as plugins
 from ckan.common import config
-from ckan.types import ErrorDict, PUploader, PResourceUploader
+from ckan.types import ErrorDict, PUploader, PResourceUploader, Response
 
 ALLOWED_UPLOAD_TYPES = (cgi.FieldStorage, FlaskFileStorage)
 MB = 1 << 20
@@ -96,6 +98,36 @@ def get_max_resource_size() -> int:
     return config.get('ckan.max_resource_size')
 
 
+def _file_hashnlength(local_path: str) -> tuple[str, int]:
+    BLOCKSIZE = 65536
+    hasher = hashlib.sha1()
+    length = 0
+
+    with open(local_path, 'rb') as afile:
+        buf = afile.read(BLOCKSIZE)
+        while len(buf) > 0:
+            hasher.update(buf)
+            length += len(buf)
+
+            buf = afile.read(BLOCKSIZE)
+
+    return (str(hasher.hexdigest()), length)
+
+
+def _add_download_headers(file_path: str,
+                          mime_type: str,
+                          response: Response) -> None:
+    """ Add appropriate 'Content-Type' and 'Content-Disposition' headers
+    to a a file download.
+    """
+    if mime_type:
+        response.headers['Content-Type'] = mime_type
+    if mime_type != 'application/pdf':
+        file_name = file_path.split('/')[-1]
+        response.headers['Content-Disposition'] = \
+            'attachment; filename=' + file_name
+
+
 class Upload(object):
     storage_path: Optional[str]
     filename: Optional[str]
@@ -149,6 +181,7 @@ class Upload(object):
         self.clear = data_dict.pop(clear_field, None)
         self.file_field = file_field
         self.upload_field_storage = data_dict.pop(file_field, None)
+        self.preserve_filename = data_dict.get('preserve_filename', None)
 
         if not self.storage_path:
             return
@@ -156,7 +189,9 @@ class Upload(object):
         if isinstance(self.upload_field_storage, ALLOWED_UPLOAD_TYPES):
             if self.upload_field_storage.filename:
                 self.filename = self.upload_field_storage.filename
-                self.filename = str(datetime.datetime.utcnow()) + self.filename
+                if not self.preserve_filename:
+                    self.filename = str(datetime.datetime.utcnow()) \
+                        + self.filename
                 self.filename = munge.munge_filename_legacy(self.filename)
                 self.filepath = os.path.join(self.storage_path, self.filename)
                 data_dict[url_field] = self.filename
@@ -224,6 +259,34 @@ class Upload(object):
         if types and type_ not in types:
             raise logic.ValidationError(err)
 
+    def delete(self, filename: str) -> None:
+        ''' Delete file we are pointing at'''
+        if not filename.startswith('http'):
+            try:
+                # Delete file from storage_path and filename
+                os.remove(os.path.join(self.storage_path, filename))
+            except OSError:
+                pass
+
+    def download(self, filename: str) -> Response:
+        ''' Generate file stream or redirect for file'''
+        filepath = os.path.join(self.storage_path, filename)
+        resp = flask.send_file(filepath)
+        content_type, content_enc = mimetypes.guess_type(filepath)
+        _add_download_headers(filepath, content_type, resp)
+        return resp
+
+    def metadata(self, filename: str) -> Union[dict[str, Any], IOError]:
+        ''' Return metadata of file'''
+        try:
+            filepath = os.path.join(self.storage_path, filename)
+            content_type, content_encoding = mimetypes.guess_type(filepath)
+            hash, length = _file_hashnlength(filepath)
+            return {'content_type': content_type, 'size': length, 'hash': hash}
+        except IOError as e:
+            log.error("Could not retrieve meta data, IOError thrown: %s", e)
+            return e
+
 
 class ResourceUpload(object):
     mimetype: Optional[str]
@@ -252,6 +315,7 @@ class ResourceUpload(object):
 
         if url and config_mimetype_guess == 'file_ext' and urlparse(url).path:
             self.mimetype = mimetypes.guess_type(url)[0]
+        self.url = url
 
         if bool(upload_field_storage) and \
                 isinstance(upload_field_storage, ALLOWED_UPLOAD_TYPES):
@@ -349,3 +413,34 @@ class ResourceUpload(object):
                 os.remove(filepath)
             except OSError:
                 pass
+
+    def delete(self, id: str, filename: Optional[str] = None) -> None:
+        ''' Delete file we are pointing at'''
+        try:
+            os.remove(self.get_path(id))
+        except OSError:
+            pass
+
+    def download(self, id: str, filename: Optional[str] = None) -> Response:
+        ''' Generate file stream or redirect for file'''
+        filepath = self.get_path(id)
+        resp = flask.send_file(filepath)
+        _add_download_headers(filepath, self.mimetype, resp)
+        return resp
+
+    def metadata(self,
+                 id: str,
+                 filename: Optional[str] = None
+                 ) -> Union[dict[str, Any], IOError]:
+        ''' Return meta details of file'''
+        try:
+            filepath = self.get_path(id)
+            if self.mimetype:
+                content_type = self.mimetype
+            else:
+                content_type = mimetypes.guess_type(self.url)[0]
+            hash, length = _file_hashnlength(filepath)
+            return {'content_type': content_type, 'size': length, 'hash': hash}
+        except IOError as e:
+            log.error("Could not retrieve metadata, IOError thrown: %s", e)
+            return e

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -13,6 +13,7 @@ from typing import Any, IO, Optional, Union
 from urllib.parse import urlparse
 
 from werkzeug.datastructures import FileStorage as FlaskFileStorage
+from werkzeug.wrappers.response import Response as WerkzeugResponse
 
 from ckan import logic, plugins
 from ckan.common import config
@@ -115,7 +116,7 @@ def _file_hashnlength(local_path: str) -> tuple[str, int]:
 
 def _add_download_headers(file_path: str,
                           mime_type: Optional[str],
-                          response: Response) -> None:
+                          response: Union[Response, WerkzeugResponse]) -> None:
     """ Add appropriate 'Content-Type' and 'Content-Disposition' headers
     to a a file download.
     """
@@ -173,7 +174,7 @@ class Upload(object):
         Storage path must be configured.
         '''
         assert self.storage_path
-        return os.path.join(self.storage_path or '', filename)
+        return os.path.join(self.storage_path, filename)
 
     def update_data_dict(self, data_dict: dict[str, Any], url_field: str,
                          file_field: str, clear_field: str) -> None:
@@ -275,7 +276,7 @@ class Upload(object):
             except OSError:
                 pass
 
-    def download(self, filename: str) -> Response:
+    def download(self, filename: str) -> Union[Response, WerkzeugResponse]:
         ''' Generate file stream or redirect for file'''
         if not self.storage_path:
             return base.abort(404, "Uploaded resource not found")
@@ -364,7 +365,7 @@ class ResourceUpload(object):
 
     def get_directory(self, id: str) -> str:
         assert self.storage_path
-        directory = os.path.join(self.storage_path or '',
+        directory = os.path.join(self.storage_path,
                                  id[0:3], id[3:6])
         return directory
 
@@ -433,7 +434,8 @@ class ResourceUpload(object):
         except OSError:
             pass
 
-    def download(self, id: str, filename: Optional[str] = None) -> Response:
+    def download(self, id: str, filename: Optional[str] = None
+                 ) -> Union[Response, WerkzeugResponse]:
         ''' Generate file stream or redirect for file'''
         filepath = self.get_path(id)
         resp = flask.send_file(filepath)
@@ -450,7 +452,7 @@ class ResourceUpload(object):
             if self.mimetype:
                 content_type = self.mimetype
             elif self.url:
-                content_type = mimetypes.guess_type(self.url or '')[0]
+                content_type = mimetypes.guess_type(self.url)[0]
             else:
                 raise IOError("No resource URL found")
             hash, length = _file_hashnlength(filepath)

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -9,12 +9,11 @@ from typing import Any, Union, Type, cast
 
 import sqlalchemy as sqla
 
-import ckan.lib.jobs as jobs
+from ckan.lib import api_token, jobs, uploader
 import ckan.logic
 import ckan.logic.action
 import ckan.logic.schema
 import ckan.plugins as plugins
-import ckan.lib.api_token as api_token
 from ckan import authz
 from  ckan.lib.navl.dictization_functions import validate
 from ckan.model.follower import ModelFollowingModel
@@ -184,6 +183,15 @@ def resource_delete(context: Context, data_dict: DataDict) -> ActionResult.Resou
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.before_resource_delete(context, data_dict,
                                       pkg_dict.get('resources', []))
+
+    # Delete file if it was uploaded
+    if pkg_dict.get('url_type') == 'upload':
+        upload = uploader.get_resource_uploader(entity)
+        # Don't break if old plugin/interface is found
+        if hasattr(upload, "delete"):
+            upload.delete(id)
+        else:
+            logging.warning("%s does not have delete function, could not cleanup: %s", type(upload).__name__, id)
 
     package_show_context: Union[Context, Any] = dict(context, for_update=True)
     pkg_dict = _get_action('package_show')(

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -186,10 +186,10 @@ def resource_delete(context: Context, data_dict: DataDict) -> ActionResult.Resou
 
     # Delete file if it was uploaded
     if pkg_dict.get('url_type') == 'upload':
-        upload = uploader.get_resource_uploader(entity)
+        upload = uploader.get_resource_uploader(pkg_dict)
         # Don't break if old plugin/interface is found
         if hasattr(upload, "delete"):
-            upload.delete(id)
+            upload.delete(id)  # type: ignore
         else:
             logging.warning("%s does not have delete function, could not cleanup: %s", type(upload).__name__, id)
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1197,15 +1197,14 @@ def resource_file_metadata_show(
     id = _get_or_bust(data_dict, 'id')
 
     resource = model.Resource.get(id)
-    resource_context = dict(context, resource=resource)
-
     if not resource:
         raise NotFound
+    context['resource'] = resource
 
-    _check_access('resource_file_metadata_show', resource_context, data_dict)
+    _check_access('resource_file_metadata_show', context, data_dict)
 
     pkg_dict = logic.get_action('package_show')(
-        dict(context),
+        context,
         {'id': resource.package.id,
          'include_tracking': asbool(data_dict.get('include_tracking', False))})
 
@@ -1218,8 +1217,8 @@ def resource_file_metadata_show(
 
     upload = uploader.get_resource_uploader(resource_dict)
     try:
-        return upload.metadata(id)
-    except IOError:
+        return upload.metadata(id)  # type: ignore
+    except (IOError, AttributeError):
         raise NotFound
 
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -16,22 +16,18 @@ from sqlalchemy import text
 
 
 import ckan
+from ckan import logic, model, plugins
 import ckan.lib.dictization
-import ckan.logic as logic
 import ckan.logic.action
 import ckan.logic.schema
 import ckan.lib.dictization.model_dictize as model_dictize
-import ckan.lib.jobs as jobs
+from ckan.lib import datapreview, jobs, plugins as lib_plugins, search, uploader
 import ckan.lib.navl.dictization_functions
-import ckan.model as model
 import ckan.model.misc as misc
-import ckan.plugins as plugins
 import ckan.lib.search as search
 from ckan.model.follower import ModelFollowingModel
 from ckan.lib.search.query import solr_literal
 
-import ckan.lib.plugins as lib_plugins
-import ckan.lib.datapreview as datapreview
 import ckan.authz as authz
 
 from ckan.common import _
@@ -1184,6 +1180,47 @@ def resource_view_list(context: Context,
         if datapreview.get_view_plugin(resource_view.view_type)
     ]
     return model_dictize.resource_view_list_dictize(resource_views, context)
+
+
+def resource_file_metadata_show(
+        context: Context, data_dict: DataDict
+        ) -> Union[dict[str, Any], IOError:
+    '''Get file metadata from a resource if it was uploaded.
+
+    :param id: the id of the resource
+    :type id: string
+
+    :returns: the meta data of resource file { 'content_type': content_type, 'size': length, 'hash': hash }
+    :rtype: dictionary
+    '''
+    model = context['model']
+    id = _get_or_bust(data_dict, 'id')
+
+    resource = model.Resource.get(id)
+    resource_context = dict(context, resource=resource)
+
+    if not resource:
+        raise NotFound
+
+    _check_access('resource_file_metadata_show', resource_context, data_dict)
+
+    pkg_dict = logic.get_action('package_show')(
+        dict(context),
+        {'id': resource.package.id,
+         'include_tracking': asbool(data_dict.get('include_tracking', False))})
+
+    for resource_dict in pkg_dict['resources']:
+        if resource_dict['id'] == id:
+            break
+    else:
+        log.error('Could not find resource %s after all', id)
+        raise NotFound(_('Resource was not found.'))
+
+    upload = uploader.get_resource_uploader(resource_dict)
+    try:
+        return upload.metadata(id)
+    except IOError:
+        raise NotFound
 
 
 def _group_or_org_show(

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1184,7 +1184,7 @@ def resource_view_list(context: Context,
 
 def resource_file_metadata_show(
         context: Context, data_dict: DataDict
-        ) -> Union[dict[str, Any], IOError:
+        ) -> Union[dict[str, Any], IOError]:
     '''Get file metadata from a resource if it was uploaded.
 
     :param id: the id of the resource

--- a/ckan/logic/action/patch.py
+++ b/ckan/logic/action/patch.py
@@ -73,6 +73,7 @@ def resource_patch(context: Context,
         'session': context['session'],
         'user': context['user'],
         'auth_user_obj': context['auth_user_obj'],
+        'ignore_auth': context.get('ignore_auth', False),
         'for_update': True
     }
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -317,10 +317,11 @@ def package_update(
         model.Session.rollback()
         raise ValidationError(errors)
 
-    #avoid revisioning by updating directly
-    model.Session.query(model.Package).filter_by(id=pkg.id).update(
-        {"metadata_modified": datetime.datetime.utcnow()})
-    model.Session.refresh(pkg)
+    if not context.get('resources_only', False):
+        #avoid revisioning by updating directly
+        model.Session.query(model.Package).filter_by(id=pkg.id).update(
+            {"metadata_modified": datetime.datetime.utcnow()})
+        model.Session.refresh(pkg)
 
     include_plugin_data = False
     user_obj = context.get('auth_user_obj')
@@ -574,6 +575,7 @@ def package_resource_reorder(
     new_resources = ordered_resources + existing_resources
     package_dict['resources'] = new_resources
 
+    context['resources_only'] = True
     _check_access('package_resource_reorder', context, package_dict)
     _get_action('package_update')(context, package_dict)
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -793,7 +793,7 @@ def user_update(context: Context, data_dict: DataDict) -> ActionResult.UserUpdat
     '''Update a user account.
 
     Normal users can only update their own user accounts. Sysadmins can update
-    any user account. Can not modify exisiting user's name.
+    any user account and modify existing usernames.
 
     .. note:: Update methods may delete parameters not explicitly provided in the
         data_dict. If you want to edit only a specific attribute use `user_patch`

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -263,6 +263,7 @@ def package_update(
     name_or_id = data_dict.get('id') or data_dict.get('name')
     if name_or_id is None:
         raise ValidationError({'id': _('Missing value')})
+    resources_only = data_dict.pop('resources_only', False)
 
     pkg = model.Package.get(name_or_id)
     if pkg is None:
@@ -317,7 +318,7 @@ def package_update(
         model.Session.rollback()
         raise ValidationError(errors)
 
-    if not context.get('resources_only', False):
+    if not resources_only:
         #avoid revisioning by updating directly
         model.Session.query(model.Package).filter_by(id=pkg.id).update(
             {"metadata_modified": datetime.datetime.utcnow()})
@@ -575,7 +576,7 @@ def package_resource_reorder(
     new_resources = ordered_resources + existing_resources
     package_dict['resources'] = new_resources
 
-    context['resources_only'] = True
+    package_dict['resources_only'] = True
     _check_access('package_resource_reorder', context, package_dict)
     _get_action('package_update')(context, package_dict)
 

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -167,6 +167,10 @@ def resource_view_list(context: Context, data_dict: DataDict) -> AuthResult:
     return authz.is_authorized('resource_show', context, data_dict)
 
 
+def resource_file_metadata_show(context: Context, data_dict: DataDict) -> AuthResult:
+    return authz.is_authorized('resource_show', context, data_dict)
+
+
 def group_show(context: Context, data_dict: DataDict) -> AuthResult:
     user = context.get('user')
     group = get_group_object(context, data_dict)

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -580,10 +580,12 @@ def user_name_validator(key: FlattenKey, data: FlattenDataDict,
             return
         else:
             # Otherwise return an error: there's already another user with that
-            # name, so you can create a new user with that name or update an
+            # name, so you can't create a new user with that name or update an
             # existing user's name to that name.
             errors[key].append(_('That login name is not available.'))
     elif user_obj_from_context:
+        if user_obj_from_context.sysadmin == True:
+            return
         old_user = model.User.get(user_obj_from_context.id)
         if old_user is not None and old_user.state != model.State.PENDING:
             errors[key].append(_('That login name can not be modified.'))

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -584,7 +584,8 @@ def user_name_validator(key: FlattenKey, data: FlattenDataDict,
             # existing user's name to that name.
             errors[key].append(_('That login name is not available.'))
     elif user_obj_from_context:
-        if user_obj_from_context.sysadmin == True:
+        requester = context.get('auth_user_obj', None)
+        if requester and requester.sysadmin == True:
             return
         old_user = model.User.get(user_obj_from_context.id)
         if old_user is not None and old_user.state != model.State.PENDING:

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1783,6 +1783,30 @@ class IUploader(Interface):
         :param max_size: upload size can be limited by this value in MBs.
         :type max_size: int
 
+        ``delete(filename)``
+
+        Perform a delete.
+
+        :param filename: The filename to use when deleting a file,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``download(filename)``
+
+        Provide redirect url or file stream
+
+        :param filename: The filename to use when downloading a file,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``metadata(filename)``
+
+        Collect metadata of file. Returns dict
+        { 'content_type': content_type, 'size': length, 'hash': hash }
+        Throws IOError if file does not exist
+
+        :param filename: The filename to use when collecting metadata
+        :type filename: string
         '''
 
     def get_resource_uploader(
@@ -1821,6 +1845,37 @@ class IUploader(Interface):
         :param id: resource id
         :type id: string
 
+        ``delete(id, filename)``
+
+        Perform a delete.
+
+        :param id: resource id, used to delete file
+        :type id: string
+        :param filename: The filename to use when storing a resource,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``download(id, filename)``
+
+        Provide redirect url or file stream
+
+        :param id: resource id, used to locate file
+        :type id: string
+        :param filename: The filename to use when storing a resource,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``metadata(id, filename)``
+
+        Collect metadata of resource. Returns dict
+        { 'content_type': content_type, 'size': length, 'hash': hash }
+        Throws IOError if file does not exist
+
+        :param id: resource id, used to locate file
+        :type id: string
+        :param filename: The filename to use when collecting metadata,
+            may be None depending on the storage provider.
+        :type filename: string
         '''
 
 

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1759,8 +1759,10 @@ class IUploader(Interface):
 
         ``update_data_dict(data_dict, url_field, file_field, clear_field)``
 
-        Allow the data_dict to be manipulated before it reaches any
-        validators.
+        Allow the data_dict to be manipulated before it reaches any validators.
+        Optionally, this data_dict can have the following attribute set:
+        preserve_filename (boolean):  If false, then the current UTC time
+        (datetime.utcnow) will be prepended to the filename.
 
         :param data_dict: data_dict to be updated
         :type data_dict: dictionary

--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -8,7 +8,11 @@
     {% block core_fields %}
       <fieldset>
         <legend>{{ _('Change details') }}</legend>
-        {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': '', 'class': 'form-control'}) }}
+        {% if g.userobj.sysadmin %}
+          {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], is_required=true) }}
+        {% else %}
+          {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': '', 'class': 'form-control'}) }}
+        {% endif %}
 
         {{ form.input('fullname', label=_('Full name'), id='field-fullname', value=data.fullname, error=errors.fullname, placeholder=_('eg. Joe Bloggs'), classes=['control-medium']) }}
 

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -428,6 +428,23 @@ class TestUser(object):
 
         assert "That login name can not be modified" in response
 
+    def test_edit_user_logged_in_username_change_by_sysadmin(
+            self, app, user, sysadmin):
+        env = {"Authorization": sysadmin["token"]}
+
+        response = app.post(
+            url=url_for("user.edit", id=user["id"]),
+            data={
+                "email": user["email"],
+                "save": "",
+                "password1": "",
+                "password2": "",
+                "name": factories.User.stub().name,
+            },
+            extra_environ=env
+        )
+        assert 'Profile updated' in response
+
     def test_perform_reset_for_key_change(self, app):
         password = "TestPassword1"
         params = {"password1": password, "password2": password}

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -170,12 +170,13 @@ def download(package_type: str,
 
     if rsc.get(u'url_type') == u'upload':
         upload = uploader.get_resource_uploader(rsc)
+        # Don't break if old plugin/interface is found
         if hasattr(upload, 'download'):
             try:
-                resp = upload.download(resource_id, filename)
+                resp = upload.download(resource_id, filename)  # type: ignore
             except (IOError, OSError):
                 # includes FileNotFoundError
-                return h.abort(404, _('Resource data not found'))
+                return base.abort(404, _('Resource data not found'))
         else:
             filepath = upload.get_path(rsc[u'id'])
             resp = flask.send_file(filepath, download_name=filename)

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -170,11 +170,18 @@ def download(package_type: str,
 
     if rsc.get(u'url_type') == u'upload':
         upload = uploader.get_resource_uploader(rsc)
-        filepath = upload.get_path(rsc[u'id'])
-        resp = flask.send_file(filepath, download_name=filename)
+        if hasattr(upload, 'download'):
+            try:
+                resp = upload.download(resource_id, filename)
+            except (IOError, OSError):
+                # includes FileNotFoundError
+                return h.abort(404, _('Resource data not found'))
+        else:
+            filepath = upload.get_path(rsc[u'id'])
+            resp = flask.send_file(filepath, download_name=filename)
 
-        if rsc.get('mimetype'):
-            resp.headers['Content-Type'] = rsc['mimetype']
+            if rsc.get('mimetype'):
+                resp.headers['Content-Type'] = rsc['mimetype']
         signals.resource_download.send(resource_id)
         return resp
 


### PR DESCRIPTION
Reapply necessary changes to support Queensland Government sites

- Add Uploader functions to improve plugin integration (eg allowing Archiver to access files from S3Filestore)
- Allow sysadmins to edit usernames
- Show full name field as "Displayed name"
- Preserve the 'ignore_auth' flag on resource patching
- Skip updating the package modification timestamp when reordering resources