### PR TITLE
QOLDEV-455 add reCAPTCHA support on CKAN 2.10

### DIFF
--- a/ckan/lib/authenticator.py
+++ b/ckan/lib/authenticator.py
@@ -4,6 +4,8 @@ import logging
 import ckan.plugins as plugins
 from typing import Any, Mapping, Optional
 
+from ckan.common import g, request
+from ckan.lib import captcha
 from ckan.model import User
 from . import signals
 
@@ -26,7 +28,20 @@ def default_authenticate(identity: 'Mapping[str, Any]') -> Optional["User"]:
     elif not user_obj.validate_password(identity['password']):
         log.debug('Login as %r failed - password not valid', login)
     else:
-        return user_obj
+        if g.recaptcha_publickey:
+            # Check for a valid reCAPTCHA response
+            try:
+                client_ip_address = request.remote_addr or 'Unknown IP Address'
+                captcha.check_recaptcha_v2_base(
+                    client_ip_address,
+                    request.form.get(u'g-recaptcha-response', '')
+                )
+                return user_obj
+            except captcha.CaptchaError:
+                log.warning('Login as %r failed - failed reCAPTCHA', login)
+                request.environ[u'captchaFailed'] = True
+        else:
+            return user_obj
     signals.failed_login.send(login)
     return None
 

--- a/ckan/lib/captcha.py
+++ b/ckan/lib/captcha.py
@@ -7,7 +7,7 @@ from ckan.types import Request
 
 
 def check_recaptcha(request: Request) -> None:
-    '''Check a user\'s recaptcha submission is valid, and raise CaptchaError
+    '''Check a user's recaptcha submission is valid, and raise CaptchaError
     on failure.'''
     recaptcha_private_key = config.get('ckan.recaptcha.privatekey')
     if not recaptcha_private_key:
@@ -17,8 +17,20 @@ def check_recaptcha(request: Request) -> None:
     client_ip_address = request.environ.get(
         'REMOTE_ADDR', 'Unknown IP Address')
 
-    # reCAPTCHA v2
     recaptcha_response_field = request.form.get('g-recaptcha-response', '')
+    check_recaptcha_v2_base(client_ip_address, recaptcha_response_field)
+
+
+def check_recaptcha_v2_base(client_ip_address: str,
+                            recaptcha_response_field: str) -> None:
+    '''Check a user's recaptcha submission is valid, and raise CaptchaError
+    on failure using discreet data'''
+    recaptcha_private_key = config.get('ckan.recaptcha.privatekey', '')
+    if not recaptcha_private_key:
+        # Recaptcha not enabled
+        return
+
+    # reCAPTCHA v2
     recaptcha_server_name = 'https://www.google.com/recaptcha/api/siteverify'
 
     # recaptcha_response_field will be unicode if there are foreign chars in

--- a/ckan/templates/user/request_reset.html
+++ b/ckan/templates/user/request_reset.html
@@ -18,6 +18,11 @@
             <label for="field-username">{{ _('Email or username') }}</label>
             <input id="field-username" class="control-medium form-control" name="user" value="" type="text" />
           </div>
+
+          {% if g.recaptcha_publickey %}
+            {% snippet "user/snippets/recaptcha.html", public_key=g.recaptcha_publickey %}
+          {% endif %}
+
           <div class="form-actions">
             {% block form_button %}
             <button class="btn btn-primary" type="submit" name="reset">{{ _("Request Reset") }}</button>

--- a/ckan/templates/user/snippets/login_form.html
+++ b/ckan/templates/user/snippets/login_form.html
@@ -14,15 +14,19 @@ Example:
 {% set username_error = true if error_summary %}
 {% set password_error = true if error_summary %}
 
-<form action="{{ action }}" method="post">
+<form action="{{ action }}" method="post" autocomplete="off">
   {{ h.csrf_input() }}
   {{ form.errors(errors=error_summary) }}
 
-  {{ form.input('login', label=_("Username or Email"), id='field-login', value="", error=username_error, classes=["control-medium"]) }}
+  {{ form.input('login', label=_("Username or Email"), id='field-login', value="", error=username_error, classes=["control-medium"], attrs={'class': 'form-control', 'autocomplete': 'off'}) }}
 
-  {{ form.input('password', label=_("Password"), id='field-password', type="password", value="", error=password_error, classes=["control-medium"]) }}
+  {{ form.input('password', label=_("Password"), id='field-password', type="password", value="", error=password_error, classes=["control-medium"], attrs={'class': 'form-control', 'autocomplete': 'off'}) }}
 
   {{ form.checkbox('remember', label=_("Remember me"), id='field-remember', checked=true, value="63072000") }}
+
+  {% if g.recaptcha_publickey %}
+    {% snippet "user/snippets/recaptcha.html", public_key=g.recaptcha_publickey %}
+  {% endif %}
 
   <div class="form-actions">
     {% block login_button %}

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -625,6 +625,14 @@ class RequestResetView(MethodView):
 
     def post(self) -> Response:
         self._prepare()
+
+        try:
+            captcha.check_recaptcha(request)
+        except captcha.CaptchaError:
+            error_msg = _(u'Bad Captcha. Please try again.')
+            h.flash_error(error_msg)
+            return h.redirect_to(u'/user/reset')
+
         id = request.form.get(u'user', '')
         if id in (None, u''):
             h.flash_error(_(u'Email is required'))


### PR DESCRIPTION
Copied and adapted from the CKAN 2.9 work. Add captcha check to default authenticator instead of Repoze FriendlyForm.