### PR TITLE
[QOLSVC-3247] make email index always non-unique, #7791

### DIFF
--- a/ckan/migration/versions/102_ff13667243ed_create_conditinal_index_on_user.py
+++ b/ckan/migration/versions/102_ff13667243ed_create_conditinal_index_on_user.py
@@ -19,15 +19,9 @@ depends_on = None
 
 
 def upgrade():
-    try:
-        op.create_index(
-            "idx_only_one_active_email", "user", ["email", "state"],
-            unique=True, postgresql_where=sa.text('"user".state=\'active\''))
-    except sa.exc.IntegrityError:
-        print("Unable to enforce unique emails. Please review your accounts.")
-        op.create_index(
-            "idx_only_one_active_email", "user", ["email", "state"],
-            unique=False, postgresql_where=sa.text('"user".state=\'active\''))
+    op.create_index(
+        "idx_only_one_active_email", "user", ["email", "state"],
+        unique=False, postgresql_where=sa.text('"user".state=\'active\''))
 
 
 def downgrade():


### PR DESCRIPTION
- Can't fall back to non-unique in the case of error, because error triggers a rollback that invalidates further statements
