### PR TITLE
[QOLSVC-2447] fix variable name

### DIFF
--- a/ckan/templates/package/resource_edit_base.html
+++ b/ckan/templates/package/resource_edit_base.html
@@ -8,7 +8,7 @@
 {% block breadcrumb_content %}
   {{ super() }}
   {% if res %}
-      <li>{% link_for h.resource_display_name(res)|truncate(30), named_route=pkg.type ~ '_resource.read', id=pkg.name, resource_id=res.id, title=h.resource_display_name(resource) %}</li>
+      <li>{% link_for h.resource_display_name(res)|truncate(30), named_route=pkg.type ~ '_resource.read', id=pkg.name, resource_id=res.id, title=h.resource_display_name(res) %}</li>
       <li{% block breadcrumb_edit_selected %} class="active"{% endblock %}><a href="">{{ _('Edit') }}</a></li>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
Obsolete if CKAN 2.10 upgrade works out, but best to be tidy.