### PR TITLE
[QOLDEV-640] disable all caching on _logout URL

### DIFF
--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -560,14 +560,21 @@ def login() -> Union[Response, str]:
     return base.render("user/login.html", extra_vars)
 
 
+def _uncached_response(response: Response) -> Response:
+    """ Ensure some types of responses are not cached at all, even privately
+    """
+    response.cache_control.no_store = True
+    return response
+
+
 def logout() -> Response:
     for item in plugins.PluginImplementations(plugins.IAuthenticator):
         response = item.logout()
         if response:
-            return response
+            return _uncached_response(response)
     user = current_user.name
     if not user:
-        return h.redirect_to('user.login')
+        return _uncached_response(h.redirect_to('user.login'))
 
     came_from = request.args.get('came_from', '')
     logout_user()
@@ -576,10 +583,9 @@ def logout() -> Response:
     if session.get(field_name):
         session.pop(field_name)
 
-    if h.url_is_local(came_from):
-        return h.redirect_to(str(came_from))
-
-    return h.redirect_to('user.logged_out_page')
+    return _uncached_response(h.redirect_to(
+        str(came_from) if h.url_is_local(came_from) else 'user.logged_out_page'
+    ))
 
 
 def logged_out_page() -> str:


### PR DESCRIPTION
By default any authenticated page will be stored in browser cache, which is secure enough, but we don't want `_logout` cached at all, because despite being a GET request, it has a crucial side effect.