### PR TITLE
[QOLDEV-640] convert logout link into a POST

### DIFF
--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -39,10 +39,12 @@
         </li>
         {% endblock %} {% block header_account_log_out_link %}
         <li>
-          <a href="{{ h.url_for('user.logout') }}" title="{{ _('Log out') }}">
-            <i class="fa fa-sign-out" aria-hidden="true"></i>
-            <span class="text">{{ _('Log out') }}</span>
-          </a>
+          <form action="{{ h.url_for('user.logout') }}" method="post">
+            {{ h.csrf_input() }}
+            <button class="btn btn-link" type="submit" title="{{ _('Log out') }}">
+              <i class="fa fa-sign-out" aria-hidden="true"></i>
+            </button>
+          </form>
         </li>
         {% endblock %} {% endblock %}
       </ul>
@@ -98,14 +100,14 @@
               {% set org_type = h.default_group_type('organization') %}
               {% set group_type = h.default_group_type('group') %}
 
-		          {{ h.build_nav_main(
-		            (dataset_type ~ '.search', h.humanize_entity_type('package', dataset_type, 'main nav') or _('Datasets'), ["dataset", "resource"]),
-		            (org_type ~ '.index',
+              {{ h.build_nav_main(
+                (dataset_type ~ '.search', h.humanize_entity_type('package', dataset_type, 'main nav') or _('Datasets'), ["dataset", "resource"]),
+                (org_type ~ '.index',
                   h.humanize_entity_type('organization', org_type, 'main nav') or _('Organizations'), ['organization']),
-		            (group_type ~ '.index',
+                (group_type ~ '.index',
                   h.humanize_entity_type('group', group_type, 'main nav') or _('Groups'), ['group']),
-		            ('home.about', _('About')) ) }}
-	          {% endblock %}
+                ('home.about', _('About')) ) }}
+            {% endblock %}
           </ul>
 
       {% endblock %}

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -929,7 +929,7 @@ user.add_url_rule(
     u'/register', view_func=RegisterView.as_view(str(u'register')))
 
 user.add_url_rule(u'/login', view_func=login, methods=('GET', 'POST'))
-user.add_url_rule(u'/_logout', view_func=logout)
+user.add_url_rule(u'/_logout', view_func=logout, methods=('GET', 'POST'))
 user.add_url_rule(u'/logged_out_redirect', view_func=logged_out_page)
 
 user.add_url_rule(u'/delete/<id>', view_func=delete, methods=(u'POST', ))


### PR DESCRIPTION
Logging out is state-changing so it should not be a GET, see GitHub #7892

Fixes #7892

### Proposed fixes:

Logging out will use a POST form submit (including CSRF token), rather than a GET.
