### PR TITLE
[QOLSVC-3914] detect and alert when page should be logged in

### DIFF
--- a/ckan/public/base/javascript/reload-on-stale-cache.js
+++ b/ckan/public/base/javascript/reload-on-stale-cache.js
@@ -1,0 +1,11 @@
+$.ajax({
+    type: "HEAD",
+    async: false,
+    cache: false,
+    url: "/dashboard",
+    success: function(message) {
+        if (confirm("It looks like you're logged in. This page may be out of date. Reload?")) {
+            location.reload();
+        }
+    }
+});

--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -58,6 +58,7 @@
         <li>{% link_for _('Register'), named_route='user.register', class_='sub' %}</li>
         {% endif %} {% endblock %}
       </ul>
+      <script type="text/javascript" src="/base/javascript/reload-on-stale-cache.js" defer></script>
     </nav>
     {% endif %} {% endblock %}
   </div>


### PR DESCRIPTION
- When rendering a login link, send a HEAD request to the dashboard to detect whether already logged in. This should be able to detect when rendering a stale cache.

Should mitigate #6955
