### PR TITLE
[QOLSVC-3914] move login check script inside appropriate template block

### DIFF
--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -54,11 +54,11 @@
       <ul class="list-unstyled">
         {% block header_account_notlogged %}
         <li>{% link_for _('Log in'), named_route='user.login' %}</li>
+        <script type="text/javascript" src="/base/javascript/reload-on-stale-cache.js" defer></script>
         {% if h.check_access('user_create') %}
         <li>{% link_for _('Register'), named_route='user.register', class_='sub' %}</li>
         {% endif %} {% endblock %}
       </ul>
-      <script type="text/javascript" src="/base/javascript/reload-on-stale-cache.js" defer></script>
     </nav>
     {% endif %} {% endblock %}
   </div>


### PR DESCRIPTION
- To minimise the risks of being overridden by plugins (specifically, ckanext-data-qld), we should keep the script inside the 'notlogged' block
