### PR TITLE
QOLDEV-692 update forked changes to CKAN 2.10.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,18 @@ Changelog
 
 .. towncrier release notes start
 
+v.2.10.x 2023-xx-xx
+==================
+
+Major features
+--------------
+
+- Update to Interface IUploader, on get_uploader and get_resource_uploader,
+  new to include new method signature metadata() which can be utilised by
+  archiver and other plugins instead of trying on local disk directly
+- Add get API `resource_file_metadata_show` which takes resource ID and returns
+  { 'content_type': content_type, 'size': length, 'hash': hash } if found
+
 v.2.10.3 2023-12-13
 ===================
 

--- a/ckan/cli/shell.py
+++ b/ckan/cli/shell.py
@@ -28,7 +28,7 @@ def ipython(namespace: Mapping[str, Any], banner: str) -> None:
     from traitlets.config.loader import Config
 
     c = Config()
-    c.TerminalInteractiveShell.banner2 = banner
+    c.TerminalInteractiveShell.banner2 = banner  # type: ignore
 
     IPython.start_ipython([], user_ns=namespace, config=c)
 

--- a/ckan/i18n/en_AU/LC_MESSAGES/ckan.po
+++ b/ckan/i18n/en_AU/LC_MESSAGES/ckan.po
@@ -3202,7 +3202,7 @@ msgstr "Change details"
 
 #: ckan/templates/user/edit_user_form.html:13
 msgid "Full name"
-msgstr "Full name"
+msgstr "Displayed name"
 
 #: ckan/templates/user/edit_user_form.html:13
 msgid "eg. Joe Bloggs"
@@ -3374,7 +3374,7 @@ msgstr "username"
 
 #: ckan/templates/user/new_user_form.html:11
 msgid "Full Name"
-msgstr "Full Name"
+msgstr "Displayed Name"
 
 #: ckan/templates/user/new_user_form.html:37
 msgid "Create Account"

--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from threading import Lock
 from typing import Any, Union
 from packaging.version import parse as parse_version
@@ -224,7 +223,7 @@ class _Globals(object):
         version = parse_version(self.ckan_version)
         self.ckan_base_version = version.base_version
         if not version.is_prerelease:
-            self.ckan_doc_version = f"{version.major}.{version.minor}"
+            self.ckan_doc_version = f"{version.major}.{version.minor}"  # type: ignore
         else:
             self.ckan_doc_version = "latest"
         # process the config details to set globals

--- a/ckan/lib/authenticator.py
+++ b/ckan/lib/authenticator.py
@@ -4,6 +4,8 @@ import logging
 import ckan.plugins as plugins
 from typing import Any, Mapping, Optional
 
+from ckan.common import g, request
+from ckan.lib import captcha
 from ckan.model import User
 from . import signals
 
@@ -26,7 +28,20 @@ def default_authenticate(identity: 'Mapping[str, Any]') -> Optional["User"]:
     elif not user_obj.validate_password(identity['password']):
         log.debug('Login as %r failed - password not valid', login)
     else:
-        return user_obj
+        if g.recaptcha_publickey:
+            # Check for a valid reCAPTCHA response
+            try:
+                client_ip_address = request.remote_addr or 'Unknown IP Address'
+                captcha.check_recaptcha_v2_base(
+                    client_ip_address,
+                    request.form.get(u'g-recaptcha-response', '')
+                )
+                return user_obj
+            except captcha.CaptchaError:
+                log.warning('Login as %r failed - failed reCAPTCHA', login)
+                request.environ[u'captchaFailed'] = True
+        else:
+            return user_obj
     signals.failed_login.send(login)
     return None
 

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -130,6 +130,8 @@ def _allow_caching(cache_force: Optional[bool] = None):
     elif not config.get('ckan.cache_enabled'):
         allow_cache = False
 
+    # Any rendered template will have a login-sensitive header
+    request.environ['__limit_cache_by_cookie__'] = True
     if not allow_cache:
         # Prevent any further rendering from being cached.
         request.environ['__no_cache__'] = True

--- a/ckan/lib/captcha.py
+++ b/ckan/lib/captcha.py
@@ -7,7 +7,7 @@ from ckan.types import Request
 
 
 def check_recaptcha(request: Request) -> None:
-    '''Check a user\'s recaptcha submission is valid, and raise CaptchaError
+    '''Check a user's recaptcha submission is valid, and raise CaptchaError
     on failure.'''
     recaptcha_private_key = config.get('ckan.recaptcha.privatekey')
     if not recaptcha_private_key:
@@ -17,8 +17,20 @@ def check_recaptcha(request: Request) -> None:
     client_ip_address = request.environ.get(
         'REMOTE_ADDR', 'Unknown IP Address')
 
-    # reCAPTCHA v2
     recaptcha_response_field = request.form.get('g-recaptcha-response', '')
+    check_recaptcha_v2_base(client_ip_address, recaptcha_response_field)
+
+
+def check_recaptcha_v2_base(client_ip_address: str,
+                            recaptcha_response_field: str) -> None:
+    '''Check a user's recaptcha submission is valid, and raise CaptchaError
+    on failure using discreet data'''
+    recaptcha_private_key = config.get('ckan.recaptcha.privatekey', '')
+    if not recaptcha_private_key:
+        # Recaptcha not enabled
+        return
+
+    # reCAPTCHA v2
     recaptcha_server_name = 'https://www.google.com/recaptcha/api/siteverify'
 
     # recaptcha_response_field will be unicode if there are foreign chars in

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -248,6 +248,9 @@ class PackageSearchIndex(SearchIndex):
                 except DateParserError:
                     log.warning('%r: %r value of %r is not a valid date', pkg_dict['id'], key, value)
                     continue
+            if type(value) is dict:
+                # Solr 8+ chokes on passing dict values unless doing an atomic update
+                value = str(value)
             new_dict[key] = value
 
         pkg_dict = new_dict

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -248,9 +248,9 @@ class PackageSearchIndex(SearchIndex):
                 except DateParserError:
                     log.warning('%r: %r value of %r is not a valid date', pkg_dict['id'], key, value)
                     continue
-            if type(value) is dict:
+            if isinstance(value, dict):
                 # Solr 8+ chokes on passing dict values unless doing an atomic update
-                value = str(value)
+                value = json.dumps(value)
             new_dict[key] = value
 
         pkg_dict = new_dict

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -1,22 +1,25 @@
 # encoding: utf-8
 from __future__ import annotations
 
+import flask
+import hashlib
 import os
 import cgi
 import datetime
 import logging
 import magic
 import mimetypes
+import six
 from typing import Any, IO, Optional, Union
 from urllib.parse import urlparse
 
 from werkzeug.datastructures import FileStorage as FlaskFileStorage
+from werkzeug.wrappers.response import Response as WerkzeugResponse
 
-import ckan.lib.munge as munge
-import ckan.logic as logic
-import ckan.plugins as plugins
+from ckan import logic, plugins
 from ckan.common import config
-from ckan.types import ErrorDict, PUploader, PResourceUploader
+from ckan.lib import base, munge
+from ckan.types import ErrorDict, PUploader, PResourceUploader, Response
 
 ALLOWED_UPLOAD_TYPES = (cgi.FieldStorage, FlaskFileStorage)
 MB = 1 << 20
@@ -96,6 +99,36 @@ def get_max_resource_size() -> int:
     return config.get('ckan.max_resource_size')
 
 
+def _file_hashnlength(local_path: str) -> tuple[str, int]:
+    BLOCKSIZE = 65536
+    hasher = hashlib.sha1()
+    length = 0
+
+    with open(local_path, 'rb') as afile:
+        buf = afile.read(BLOCKSIZE)
+        while len(buf) > 0:
+            hasher.update(buf)
+            length += len(buf)
+
+            buf = afile.read(BLOCKSIZE)
+
+    return (str(hasher.hexdigest()), length)
+
+
+def _add_download_headers(file_path: str,
+                          mime_type: Optional[str],
+                          response: Union[Response, WerkzeugResponse]) -> None:
+    """ Add appropriate 'Content-Type' and 'Content-Disposition' headers
+    to a a file download.
+    """
+    if mime_type:
+        response.headers['Content-Type'] = mime_type
+    if mime_type != 'application/pdf':
+        file_name = file_path.split('/')[-1]
+        response.headers['Content-Disposition'] = \
+            'attachment; filename=' + file_name
+
+
 class Upload(object):
     storage_path: Optional[str]
     filename: Optional[str]
@@ -118,15 +151,16 @@ class Upload(object):
         path = get_storage_path()
         if not path:
             return
-        self.storage_path = os.path.join(path, 'storage',
-                                         'uploads', object_type)
+        path = os.path.join(path, 'storage', 'uploads', object_type)
+        self.storage_path = path
+
         # check if the storage directory is already created by
         # the user or third-party
-        if os.path.isdir(self.storage_path):
+        if os.path.isdir(path):
             pass
         else:
             try:
-                os.makedirs(self.storage_path)
+                os.makedirs(path)
             except OSError as e:
                 # errno 17 is file already exists
                 if e.errno != 17:
@@ -134,7 +168,14 @@ class Upload(object):
         self.object_type = object_type
         self.old_filename = old_filename
         if old_filename:
-            self.old_filepath = os.path.join(self.storage_path, old_filename)
+            self.old_filepath = os.path.join(path, old_filename)
+
+    def _get_storage_path_for(self, filename: str) -> str:
+        '''Function to get the path to a stored file.
+        Storage path must be configured.
+        '''
+        assert self.storage_path
+        return os.path.join(self.storage_path, six.ensure_str(filename))
 
     def update_data_dict(self, data_dict: dict[str, Any], url_field: str,
                          file_field: str, clear_field: str) -> None:
@@ -149,6 +190,7 @@ class Upload(object):
         self.clear = data_dict.pop(clear_field, None)
         self.file_field = file_field
         self.upload_field_storage = data_dict.pop(file_field, None)
+        self.preserve_filename = data_dict.get('preserve_filename', None)
 
         if not self.storage_path:
             return
@@ -156,9 +198,11 @@ class Upload(object):
         if isinstance(self.upload_field_storage, ALLOWED_UPLOAD_TYPES):
             if self.upload_field_storage.filename:
                 self.filename = self.upload_field_storage.filename
-                self.filename = str(datetime.datetime.utcnow()) + self.filename
+                if not self.preserve_filename:
+                    self.filename = str(datetime.datetime.utcnow()) \
+                        + self.filename
                 self.filename = munge.munge_filename_legacy(self.filename)
-                self.filepath = os.path.join(self.storage_path, self.filename)
+                self.filepath = self._get_storage_path_for(self.filename)
                 data_dict[url_field] = self.filename
                 self.upload_file = _get_underlying_file(
                     self.upload_field_storage)
@@ -224,9 +268,42 @@ class Upload(object):
         if types and type_ not in types:
             raise logic.ValidationError(err)
 
+    def delete(self, filename: str) -> None:
+        ''' Delete file we are pointing at'''
+        if self.storage_path and not filename.startswith('http'):
+            try:
+                # Delete file from storage_path and filename
+                os.remove(self._get_storage_path_for(filename))
+            except OSError:
+                pass
+
+    def download(self, filename: str) -> Union[Response, WerkzeugResponse]:
+        ''' Generate file stream or redirect for file'''
+        if not self.storage_path:
+            return base.abort(404, "Uploaded resource not found")
+        filepath = self._get_storage_path_for(filename)
+        resp = flask.send_file(filepath)
+        content_type, _ = mimetypes.guess_type(filepath)
+        _add_download_headers(filepath, content_type, resp)
+        return resp
+
+    def metadata(self, filename: str) -> Union[dict[str, Any], IOError]:
+        ''' Return metadata of file'''
+        if not self.storage_path:
+            return {}
+        try:
+            filepath = self._get_storage_path_for(filename)
+            content_type, _ = mimetypes.guess_type(filepath)
+            hash, length = _file_hashnlength(filepath)
+            return {'content_type': content_type, 'size': length, 'hash': hash}
+        except IOError as e:
+            log.error("Could not retrieve meta data, IOError thrown: %s", e)
+            return e
+
 
 class ResourceUpload(object):
     mimetype: Optional[str]
+    url: Optional[str]
 
     def __init__(self, resource: dict[str, Any]) -> None:
         path = get_storage_path()
@@ -252,6 +329,7 @@ class ResourceUpload(object):
 
         if url and config_mimetype_guess == 'file_ext' and urlparse(url).path:
             self.mimetype = mimetypes.guess_type(url)[0]
+        self.url = url
 
         if bool(upload_field_storage) and \
                 isinstance(upload_field_storage, ALLOWED_UPLOAD_TYPES):
@@ -359,3 +437,37 @@ class ResourceUpload(object):
                 os.remove(filepath)
             except OSError:
                 pass
+
+    def delete(self, id: str, filename: Optional[str] = None) -> None:
+        ''' Delete file we are pointing at'''
+        try:
+            os.remove(self.get_path(id))
+        except OSError:
+            pass
+
+    def download(self, id: str, filename: Optional[str] = None
+                 ) -> Union[Response, WerkzeugResponse]:
+        ''' Generate file stream or redirect for file'''
+        filepath = self.get_path(id)
+        resp = flask.send_file(filepath)
+        _add_download_headers(filepath, self.mimetype, resp)
+        return resp
+
+    def metadata(self,
+                 id: str,
+                 filename: Optional[str] = None
+                 ) -> Union[dict[str, Any], IOError]:
+        ''' Return meta details of file'''
+        try:
+            filepath = self.get_path(id)
+            if self.mimetype:
+                content_type = self.mimetype
+            elif self.url:
+                content_type = mimetypes.guess_type(self.url)[0]
+            else:
+                raise IOError("No resource URL found")
+            hash, length = _file_hashnlength(filepath)
+            return {'content_type': content_type, 'size': length, 'hash': hash}
+        except IOError as e:
+            log.error("Could not retrieve metadata, IOError thrown: %s", e)
+            return e

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -9,12 +9,11 @@ from typing import Any, Union, Type, cast
 
 import sqlalchemy as sqla
 
-import ckan.lib.jobs as jobs
+from ckan.lib import api_token, jobs, uploader
 import ckan.logic
 import ckan.logic.action
 import ckan.logic.schema
 import ckan.plugins as plugins
-import ckan.lib.api_token as api_token
 from ckan import authz
 from  ckan.lib.navl.dictization_functions import validate
 from ckan.model.follower import ModelFollowingModel
@@ -184,6 +183,15 @@ def resource_delete(context: Context, data_dict: DataDict) -> ActionResult.Resou
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.before_resource_delete(context, data_dict,
                                       pkg_dict.get('resources', []))
+
+    # Delete file if it was uploaded
+    if pkg_dict.get('url_type') == 'upload':
+        upload = uploader.get_resource_uploader(pkg_dict)
+        # Don't break if old plugin/interface is found
+        if hasattr(upload, "delete"):
+            upload.delete(id)  # type: ignore
+        else:
+            log.warning("%s does not have delete function, could not cleanup: %s", type(upload).__name__, id)
 
     package_show_context: Union[Context, Any] = dict(context, for_update=True)
     pkg_dict = _get_action('package_show')(

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -16,22 +16,18 @@ from sqlalchemy import text
 
 
 import ckan
+from ckan import logic, model, plugins
 import ckan.lib.dictization
-import ckan.logic as logic
 import ckan.logic.action
 import ckan.logic.schema
 import ckan.lib.dictization.model_dictize as model_dictize
-import ckan.lib.jobs as jobs
+from ckan.lib import datapreview, jobs, plugins as lib_plugins, search, uploader
 import ckan.lib.navl.dictization_functions
-import ckan.model as model
 import ckan.model.misc as misc
-import ckan.plugins as plugins
 import ckan.lib.search as search
 from ckan.model.follower import ModelFollowingModel
 from ckan.lib.search.query import solr_literal
 
-import ckan.lib.plugins as lib_plugins
-import ckan.lib.datapreview as datapreview
 import ckan.authz as authz
 
 from ckan.common import _
@@ -1184,6 +1180,46 @@ def resource_view_list(context: Context,
         if datapreview.get_view_plugin(resource_view.view_type)
     ]
     return model_dictize.resource_view_list_dictize(resource_views, context)
+
+
+def resource_file_metadata_show(
+        context: Context, data_dict: DataDict
+        ) -> Union[dict[str, Any], IOError]:
+    '''Get file metadata from a resource if it was uploaded.
+
+    :param id: the id of the resource
+    :type id: string
+
+    :returns: the meta data of resource file { 'content_type': content_type, 'size': length, 'hash': hash }
+    :rtype: dictionary
+    '''
+    model = context['model']
+    id = _get_or_bust(data_dict, 'id')
+
+    resource = model.Resource.get(id)
+    if not resource:
+        raise NotFound
+    context['resource'] = resource
+
+    _check_access('resource_file_metadata_show', context, data_dict)
+
+    pkg_dict = logic.get_action('package_show')(
+        context,
+        {'id': resource.package.id,
+         'include_tracking': asbool(data_dict.get('include_tracking', False))})
+
+    for resource_dict in pkg_dict['resources']:
+        if resource_dict['id'] == id:
+            break
+    else:
+        log.error('Could not find resource %s after all', id)
+        raise NotFound(_('Resource was not found.'))
+
+    upload = uploader.get_resource_uploader(resource_dict)
+    try:
+        return upload.metadata(id)  # type: ignore
+    except (IOError, AttributeError):
+        raise NotFound
 
 
 def _group_or_org_show(

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -794,7 +794,7 @@ def user_update(context: Context, data_dict: DataDict) -> ActionResult.UserUpdat
     '''Update a user account.
 
     Normal users can only update their own user accounts. Sysadmins can update
-    any user account. Can not modify exisiting user's name.
+    any user account and modify existing usernames.
 
     .. note:: Update methods may delete parameters not explicitly provided in the
         data_dict. If you want to edit only a specific attribute use `user_patch`

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -263,6 +263,7 @@ def package_update(
     name_or_id = data_dict.get('id') or data_dict.get('name')
     if name_or_id is None:
         raise ValidationError({'id': _('Missing value')})
+    resources_only = data_dict.pop('resources_only', False)
 
     pkg = model.Package.get(name_or_id)
     if pkg is None:
@@ -317,10 +318,11 @@ def package_update(
         model.Session.rollback()
         raise ValidationError(errors)
 
-    #avoid revisioning by updating directly
-    model.Session.query(model.Package).filter_by(id=pkg.id).update(
-        {"metadata_modified": datetime.datetime.utcnow()})
-    model.Session.refresh(pkg)
+    if not resources_only:
+        #avoid revisioning by updating directly
+        model.Session.query(model.Package).filter_by(id=pkg.id).update(
+            {"metadata_modified": datetime.datetime.utcnow()})
+        model.Session.refresh(pkg)
 
     include_plugin_data = False
     user_obj = context.get('auth_user_obj')
@@ -574,6 +576,7 @@ def package_resource_reorder(
     new_resources = ordered_resources + existing_resources
     package_dict['resources'] = new_resources
 
+    package_dict['resources_only'] = True
     _check_access('package_resource_reorder', context, package_dict)
     _get_action('package_update')(context, package_dict)
 

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -167,6 +167,10 @@ def resource_view_list(context: Context, data_dict: DataDict) -> AuthResult:
     return authz.is_authorized('resource_show', context, data_dict)
 
 
+def resource_file_metadata_show(context: Context, data_dict: DataDict) -> AuthResult:
+    return authz.is_authorized('resource_show', context, data_dict)
+
+
 def group_show(context: Context, data_dict: DataDict) -> AuthResult:
     user = context.get('user')
     group = get_group_object(context, data_dict)

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -615,10 +615,13 @@ def user_name_validator(key: FlattenKey, data: FlattenDataDict,
             return
         else:
             # Otherwise return an error: there's already another user with that
-            # name, so you can create a new user with that name or update an
+            # name, so you can't create a new user with that name or update an
             # existing user's name to that name.
             errors[key].append(_('That login name is not available.'))
     elif user_obj_from_context:
+        requester = context.get('auth_user_obj', None)
+        if requester and requester.sysadmin == True:
+            return
         old_user = model.User.get(user_obj_from_context.id)
         if old_user is not None and old_user.state != model.State.PENDING:
             errors[key].append(_('That login name can not be modified.'))

--- a/ckan/migration/versions/102_ff13667243ed_create_conditinal_index_on_user.py
+++ b/ckan/migration/versions/102_ff13667243ed_create_conditinal_index_on_user.py
@@ -21,7 +21,7 @@ depends_on = None
 def upgrade():
     op.create_index(
         "idx_only_one_active_email", "user", ["email", "state"],
-        unique=True, postgresql_where=sa.text('"user".state=\'active\''))
+        unique=False, postgresql_where=sa.text('"user".state=\'active\''))
 
 
 def downgrade():

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1759,8 +1759,10 @@ class IUploader(Interface):
 
         ``update_data_dict(data_dict, url_field, file_field, clear_field)``
 
-        Allow the data_dict to be manipulated before it reaches any
-        validators.
+        Allow the data_dict to be manipulated before it reaches any validators.
+        Optionally, this data_dict can have the following attribute set:
+        preserve_filename (boolean):  If false, then the current UTC time
+        (datetime.utcnow) will be prepended to the filename.
 
         :param data_dict: data_dict to be updated
         :type data_dict: dictionary
@@ -1783,6 +1785,30 @@ class IUploader(Interface):
         :param max_size: upload size can be limited by this value in MBs.
         :type max_size: int
 
+        ``delete(filename)``
+
+        Perform a delete.
+
+        :param filename: The filename to use when deleting a file,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``download(filename)``
+
+        Provide redirect url or file stream
+
+        :param filename: The filename to use when downloading a file,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``metadata(filename)``
+
+        Collect metadata of file. Returns dict
+        { 'content_type': content_type, 'size': length, 'hash': hash }
+        Throws IOError if file does not exist
+
+        :param filename: The filename to use when collecting metadata
+        :type filename: string
         '''
 
     def get_resource_uploader(
@@ -1821,6 +1847,37 @@ class IUploader(Interface):
         :param id: resource id
         :type id: string
 
+        ``delete(id, filename)``
+
+        Perform a delete.
+
+        :param id: resource id, used to delete file
+        :type id: string
+        :param filename: The filename to use when storing a resource,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``download(id, filename)``
+
+        Provide redirect url or file stream
+
+        :param id: resource id, used to locate file
+        :type id: string
+        :param filename: The filename to use when storing a resource,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``metadata(id, filename)``
+
+        Collect metadata of resource. Returns dict
+        { 'content_type': content_type, 'size': length, 'hash': hash }
+        Throws IOError if file does not exist
+
+        :param id: resource id, used to locate file
+        :type id: string
+        :param filename: The filename to use when collecting metadata,
+            may be None depending on the storage provider.
+        :type filename: string
         '''
 
 

--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -39,10 +39,12 @@
         </li>
         {% endblock %} {% block header_account_log_out_link %}
         <li>
-          <a href="{{ h.url_for('user.logout') }}" title="{{ _('Log out') }}">
-            <i class="fa fa-sign-out" aria-hidden="true"></i>
-            <span class="text">{{ _('Log out') }}</span>
-          </a>
+          <form action="{{ h.url_for('user.logout') }}" method="post">
+            {{ h.csrf_input() }}
+            <button class="btn btn-link" type="submit" title="{{ _('Log out') }}">
+              <i class="fa fa-sign-out" aria-hidden="true"></i>
+            </button>
+          </form>
         </li>
         {% endblock %} {% endblock %}
       </ul>
@@ -98,14 +100,14 @@
               {% set org_type = h.default_group_type('organization') %}
               {% set group_type = h.default_group_type('group') %}
 
-		          {{ h.build_nav_main(
-		            (dataset_type ~ '.search', h.humanize_entity_type('package', dataset_type, 'main nav') or _('Datasets'), ["dataset", "resource"]),
-		            (org_type ~ '.index',
+                  {{ h.build_nav_main(
+                    (dataset_type ~ '.search', h.humanize_entity_type('package', dataset_type, 'main nav') or _('Datasets'), ["dataset", "resource"]),
+                    (org_type ~ '.index',
                   h.humanize_entity_type('organization', org_type, 'main nav') or _('Organizations'), ['organization']),
-		            (group_type ~ '.index',
+                    (group_type ~ '.index',
                   h.humanize_entity_type('group', group_type, 'main nav') or _('Groups'), ['group']),
-		            ('home.about', _('About')) ) }}
-	          {% endblock %}
+                    ('home.about', _('About')) ) }}
+              {% endblock %}
           </ul>
 
       {% endblock %}

--- a/ckan/templates/user/dashboard_organizations.html
+++ b/ckan/templates/user/dashboard_organizations.html
@@ -1,15 +1,13 @@
 {% extends "user/dashboard.html" %}
 
-{% set group_type = h.default_group_type('organization') %}
-
 {% block page_primary_action %}
   {% if h.check_access('organization_create') %}
-    {% link_for h.humanize_entity_type('organization', group_type, 'add link') or _('Add Organization'), named_route=group_type ~ '.new', class_="btn btn-primary", icon="plus-square" %}
+    {% link_for h.humanize_entity_type('organization', org_type, 'add link') or _('Add Organization'), named_route=org_type ~ '.new', class_="btn btn-primary", icon="plus-square" %}
   {% endif %}
 {% endblock %}
 
 {% block primary_content_inner %}
-  <h2 class="hide-heading">{{ h.humanize_entity_type('organization', group_type, 'my label') or _('My Organizations') }}</h2>
+  <h2 class="hide-heading">{{ h.humanize_entity_type('organization', org_type, 'my label') or _('My Organizations') }}</h2>
   {% set organizations = h.organizations_available(permission='manage_group',
     include_dataset_count=True) %}
   {% if organizations %}
@@ -18,9 +16,9 @@
     </div>
   {% else %}
     <p class="empty">
-      {{ h.humanize_entity_type('organization', group_type, 'you not member') or _('You are not a member of any organizations.') }}
+      {{ h.humanize_entity_type('organization', org_type, 'you not member') or _('You are not a member of any organizations.') }}
       {% if h.check_access('organization_create') %}
-        {% link_for _('Create one now?'), named_route=group_type ~ '.new' %}
+        {% link_for _('Create one now?'), named_route=org_type ~ '.new' %}
       {% endif %}
     </p>
   {% endif %}

--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -8,7 +8,11 @@
     {% block core_fields %}
       <fieldset>
         <legend>{{ _('Change details') }}</legend>
-        {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': '', 'class': 'form-control'}) }}
+        {% if g.userobj.sysadmin %}
+          {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], is_required=true) }}
+        {% else %}
+          {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': '', 'class': 'form-control'}) }}
+        {% endif %}
 
         {{ form.input('fullname', label=_('Full name'), id='field-fullname', value=data.fullname, error=errors.fullname, placeholder=_('eg. Joe Bloggs'), classes=['control-medium']) }}
 

--- a/ckan/templates/user/request_reset.html
+++ b/ckan/templates/user/request_reset.html
@@ -18,6 +18,11 @@
             <label for="field-username">{{ _('Email or username') }}</label>
             <input id="field-username" class="control-medium form-control" name="user" value="" type="text" />
           </div>
+
+          {% if g.recaptcha_publickey %}
+            {% snippet "user/snippets/recaptcha.html", public_key=g.recaptcha_publickey %}
+          {% endif %}
+
           <div class="form-actions">
             {% block form_button %}
             <button class="btn btn-primary" type="submit" name="reset">{{ _("Request Reset") }}</button>

--- a/ckan/templates/user/snippets/login_form.html
+++ b/ckan/templates/user/snippets/login_form.html
@@ -24,6 +24,10 @@ Example:
 
   {{ form.checkbox('remember', label=_("Remember me"), id='field-remember', checked=true, value="63072000") }}
 
+  {% if g.recaptcha_publickey %}
+    {% snippet "user/snippets/recaptcha.html", public_key=g.recaptcha_publickey %}
+  {% endif %}
+
   <div class="form-actions">
     {% block login_button %}
     <button class="btn btn-primary" type="submit">{{ _('Login') }}</button>

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -428,6 +428,23 @@ class TestUser(object):
 
         assert "That login name can not be modified" in response
 
+    def test_edit_user_logged_in_username_change_by_sysadmin(
+            self, app, user, sysadmin):
+        env = {"Authorization": sysadmin["token"]}
+
+        response = app.post(
+            url=url_for("user.edit", id=user["id"]),
+            data={
+                "email": user["email"],
+                "save": "",
+                "password1": "",
+                "password2": "",
+                "name": factories.User.stub().name,
+            },
+            extra_environ=env
+        )
+        assert 'Profile updated' in response
+
     def test_perform_reset_for_key_change(self, app):
         password = "TestPassword1"
         params = {"password1": password, "password2": password}

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -49,6 +49,7 @@ def set_cache_control_headers_for_response(response: Response) -> Response:
 
     # __no_cache__ should not be present when caching is allowed
     allow_cache = u'__no_cache__' not in request.environ
+    limit_cache_by_cookie = u'__limit_cache_by_cookie__' in request.environ
 
     if u'Pragma' in response.headers:
         del response.headers["Pragma"]
@@ -63,6 +64,10 @@ def set_cache_control_headers_for_response(response: Response) -> Response:
             pass
     else:
         response.cache_control.private = True
+
+    # Invalidate cached pages upon login/logout
+    if limit_cache_by_cookie:
+        response.vary.add("Cookie")
 
     return response
 

--- a/ckan/views/dashboard.py
+++ b/ckan/views/dashboard.py
@@ -26,7 +26,7 @@ def before_request() -> None:
 
         # flask types do not mention that it's possible to return a response
         # from the `before_request` callback
-        return h.redirect_to(u'user.login')  # type: ignore
+        return h.redirect_to(u'user.login')
 
     try:
         context = cast(Context, {

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -170,11 +170,19 @@ def download(package_type: str,
 
     if rsc.get(u'url_type') == u'upload':
         upload = uploader.get_resource_uploader(rsc)
-        filepath = upload.get_path(rsc[u'id'])
-        resp = flask.send_file(filepath, download_name=filename)
+        # Don't break if old plugin/interface is found
+        if hasattr(upload, 'download'):
+            try:
+                resp = upload.download(resource_id, filename)  # type: ignore
+            except (IOError, OSError):
+                # includes FileNotFoundError
+                return base.abort(404, _('Resource data not found'))
+        else:
+            filepath = upload.get_path(rsc[u'id'])
+            resp = flask.send_file(filepath, download_name=filename)
 
-        if rsc.get('mimetype'):
-            resp.headers['Content-Type'] = rsc['mimetype']
+            if rsc.get('mimetype'):
+                resp.headers['Content-Type'] = rsc['mimetype']
         signals.resource_download.send(resource_id)
         return resp
 

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -645,6 +645,14 @@ class RequestResetView(MethodView):
 
     def post(self) -> Response:
         self._prepare()
+
+        try:
+            captcha.check_recaptcha(request)
+        except captcha.CaptchaError:
+            error_msg = _(u'Bad Captcha. Please try again.')
+            h.flash_error(error_msg)
+            return h.redirect_to(u'/user/reset')
+
         id = request.form.get(u'user', '')
         if id in (None, u''):
             h.flash_error(_(u'Email is required'))

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -943,7 +943,7 @@ user.add_url_rule(
     u'/register', view_func=RegisterView.as_view(str(u'register')))
 
 user.add_url_rule(u'/login', view_func=login, methods=('GET', 'POST'))
-user.add_url_rule(u'/_logout', view_func=logout)
+user.add_url_rule(u'/_logout', view_func=logout, methods=('GET', 'POST'))
 user.add_url_rule(u'/logged_out_redirect', view_func=logged_out_page)
 
 user.add_url_rule(u'/delete/<id>', view_func=delete, methods=(u'POST', 'GET'))

--- a/ckanext/activity/model/activity.py
+++ b/ckanext/activity/model/activity.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import Any, Optional, Type, TypeVar, cast
+from typing import Any, Optional, Type, TypeVar, Union, List, Tuple, cast
 from typing_extensions import TypeAlias
 
 from sqlalchemy.orm import relationship, backref
@@ -14,6 +14,8 @@ from sqlalchemy import (
     and_,
     union_all,
     text,
+    select,
+    literal,
 )
 
 from ckan.common import config
@@ -202,16 +204,16 @@ def _activities_limit(
     q: QActivity,
     limit: int,
     offset: Optional[int] = None,
-    revese_order: Optional[bool] = False,
+    reverse_order: Optional[bool] = False,
 ) -> QActivity:
     """
     Return an SQLAlchemy query for all activities at an offset with a limit.
 
-    revese_order:
+    reverse_order:
         if we want the last activities before a date, we must reverse the
         order before limiting.
     """
-    if revese_order:
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -237,21 +239,22 @@ def _activities_union_all(*qlist: QActivity) -> QActivity:
     return q
 
 
-def _activities_from_user_query(user_id: str) -> QActivity:
+def _activities_from_user_query(user_id: Union[str, List[str]]) -> QActivity:
     """Return an SQLAlchemy query for all activities from user_id."""
     q = model.Session.query(Activity)
-    q = q.filter(Activity.user_id == user_id)
+    q = q.filter(Activity.user_id.in_(_to_list(user_id)))  # type: ignore
     return q
 
 
-def _activities_about_user_query(user_id: str) -> QActivity:
+def _activities_about_user_query(user_id: Union[str, List[str]]) -> QActivity:
     """Return an SQLAlchemy query for all activities about user_id."""
     q = model.Session.query(Activity)
-    q = q.filter(Activity.object_id == user_id)
+    q = q.filter(Activity.object_id.in_(_to_list(user_id)))  # type: ignore
     return q
 
 
-def _user_activity_query(user_id: str, limit: int) -> QActivity:
+def _user_activity_query(
+        user_id: Union[str, List[str]], limit: int) -> QActivity:
     """Return an SQLAlchemy query for all activities from or about user_id."""
     q1 = _activities_limit(_activities_from_user_query(user_id), limit)
     q2 = _activities_limit(_activities_about_user_query(user_id), limit)
@@ -288,8 +291,8 @@ def user_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -303,15 +306,22 @@ def user_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results
 
 
-def _package_activity_query(package_id: str) -> QActivity:
+def _to_list(vals: Union[List[str], Tuple[str], str]):
+    if isinstance(vals, (list, tuple)):
+        return vals
+    return [vals]
+
+
+def _package_activity_query(package_id: Union[str, List[str]]) -> QActivity:
     """Return an SQLAlchemy query for all activities about package_id."""
-    q = model.Session.query(Activity).filter_by(object_id=package_id)
+    q = model.Session.query(Activity).filter(
+        Activity.object_id.in_(_to_list(package_id)))  # type: ignore
     return q
 
 
@@ -355,8 +365,8 @@ def package_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -370,24 +380,21 @@ def package_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results
 
 
-def _group_activity_query(group_id: str) -> QActivity:
+def _group_activity_query(group_id: Union[str, List[str]]) -> QActivity:
     """Return an SQLAlchemy query for all activities about group_id.
 
     Returns a query for all activities whose object is either the group itself
     or one of the group's datasets.
 
     """
-    group = model.Group.get(group_id)
-    if not group:
-        # Return a query with no results.
-        return model.Session.query(Activity).filter(text("0=1"))
 
+    groups = _to_list(group_id)
     q: QActivity = (
         model.Session.query(Activity)
         .outerjoin(model.Member, Activity.object_id == model.Member.table_id)
@@ -407,20 +414,20 @@ def _group_activity_query(group_id: str) -> QActivity:
             or_(
                 # active dataset in the group
                 and_(
-                    model.Member.group_id == group_id,
+                    model.Member.group_id.in_(groups),  # type: ignore
                     model.Member.state == "active",
                     model.Package.state == "active",
                 ),
                 # deleted dataset in the group
                 and_(
-                    model.Member.group_id == group_id,
+                    model.Member.group_id.in_(groups),  # type: ignore
                     model.Member.state == "deleted",
                     model.Package.state == "deleted",
                 ),
                 # (we want to avoid showing changes to an active dataset that
                 # was once in this group)
                 # activity the the group itself
-                Activity.object_id == group_id,
+                Activity.object_id.in_(groups),  # type: ignore
             )
         )
     )
@@ -442,21 +449,27 @@ def _organization_activity_query(org_id: str) -> QActivity:
 
     q: QActivity = (
         model.Session.query(Activity)
-        .outerjoin(
-            model.Package,
-            and_(
-                model.Package.id == Activity.object_id,
-                model.Package.private == False,  # noqa
-            ),
-        )
         .filter(
             # We only care about activity either on the the org itself or on
             # packages within that org.
             # FIXME: This means that activity that occured while a package
             # belonged to a org but was then removed will not show up. This may
             # not be desired but is consistent with legacy behaviour.
-            or_(
-                model.Package.owner_org == org_id, Activity.object_id == org_id
+            #
+            # Use subselect instead of outer join so that it can all
+            # be indexable
+            Activity.object_id.in_(  # type: ignore
+                select([model.Package.id])  # type: ignore
+                .where(
+                    and_(
+                        model.Package.private == False,  # noqa
+                        model.Package.owner_org == org_id
+                    )
+                )
+                .union(
+                    # select the org itself
+                    select([literal(org_id)])
+                )
             )
         )
     )
@@ -500,8 +513,8 @@ def group_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -515,7 +528,7 @@ def group_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results
@@ -556,8 +569,8 @@ def organization_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -571,7 +584,7 @@ def organization_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results
@@ -588,12 +601,9 @@ def _activities_from_users_followed_by_user_query(
         # Return a query with no results.
         return model.Session.query(Activity).filter(text("0=1"))
 
-    return _activities_union_all(
-        *[
-            _user_activity_query(follower.object_id, limit)
-            for follower in follower_objects
-        ]
-    )
+    return _user_activity_query(
+        [follower.object_id for follower in follower_objects],
+        limit)
 
 
 def _activities_from_datasets_followed_by_user_query(
@@ -606,14 +616,10 @@ def _activities_from_datasets_followed_by_user_query(
         # Return a query with no results.
         return model.Session.query(Activity).filter(text("0=1"))
 
-    return _activities_union_all(
-        *[
-            _activities_limit(
-                _package_activity_query(follower.object_id), limit
-            )
-            for follower in follower_objects
-        ]
-    )
+    return _activities_limit(
+        _package_activity_query(
+            [follower.object_id for follower in follower_objects]),
+        limit)
 
 
 def _activities_from_groups_followed_by_user_query(
@@ -632,12 +638,10 @@ def _activities_from_groups_followed_by_user_query(
         # Return a query with no results.
         return model.Session.query(Activity).filter(text("0=1"))
 
-    return _activities_union_all(
-        *[
-            _activities_limit(_group_activity_query(follower.object_id), limit)
-            for follower in follower_objects
-        ]
-    )
+    return _activities_limit(
+        _group_activity_query(
+            [follower.object_id for follower in follower_objects]),
+        limit)
 
 
 def _activities_from_everything_followed_by_user_query(
@@ -698,8 +702,8 @@ def dashboard_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -713,7 +717,7 @@ def dashboard_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results

--- a/ckanext/activity/templates/package/snippets/resources.html
+++ b/ckanext/activity/templates/package/snippets/resources.html
@@ -2,7 +2,6 @@
 
 
 {% block resources_list %}
-<<<<<<< HEAD
   <ul class="list-unstyled nav nav-simple">
     {% for resource in resources %}
       <li class="nav-item{{ ' active' if active == resource.id }}">

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ Flask-Login==0.6.1
 Flask-WTF==1.0.1
 flask-multistatic==1.0
 greenlet==2.0.2
-Jinja2==3.1.2
+Jinja2==3.1.3
 PyJWT==2.4.0
 Markdown==3.4.1
 passlib==1.7.4
@@ -27,11 +27,11 @@ python-dateutil==2.8.2
 pytz
 PyUtilib==6.0.0
 pyyaml==6.0.1
-requests==2.28.1
+requests==2.31.0
 rq==1.11.0
 simplejson==3.17.6
 SQLAlchemy[mypy]==1.4.41
-sqlparse==0.4.2
+sqlparse==0.4.4
 typing_extensions==4.3.0
 tzlocal==4.2
 webassets==2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ bleach==5.0.1
     # via -r requirements.in
 blinker==1.5
     # via -r requirements.in
-certifi==2021.10.8
+certifi==2023.7.22
     # via requests
 charset-normalizer==2.0.12
     # via requests
@@ -61,7 +61,7 @@ itsdangerous==2.1.1
     # via
     #   flask
     #   flask-wtf
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   -r requirements.in
     #   flask
@@ -116,7 +116,7 @@ pyyaml==6.0.1
     # via -r requirements.in
 redis==4.1.4
     # via rq
-requests==2.28.1
+requests==2.31.0
     # via
     #   -r requirements.in
     #   pysolr
@@ -136,7 +136,7 @@ sqlalchemy[mypy]==1.4.41
     #   sqlalchemy
 sqlalchemy2-stubs==0.0.2a27
     # via sqlalchemy
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements.in
 tomli==2.0.1
     # via mypy
@@ -149,7 +149,7 @@ tzdata==2022.1
     # via pytz-deprecation-shim
 tzlocal==4.2
     # via -r requirements.in
-urllib3==1.26.9
+urllib3==1.26.18
     # via requests
 watchdog==2.1.6
     # via werkzeug


### PR DESCRIPTION
Changes already incorporated into 2.10.3:

- Passing the 'ignore_auth' flag through to the get action in resource_patch
- Disabling HTML5 URL validation on uploaded resource filenames
- Adding link titles to preserve non-truncated names
- Coalesce missing datastore values

Changes reapplied from qgov-master-2.10.1:

- Add more Uploader functions to assist plugin integrations
- Show 'full name' field as "Displayed Name" since that's really what it is
- Add reCAPTCHA validation on login
- Invalidate page caches when cookies change
- Convert JSON-format package fields to plain string before indexing in Solr
- Don't update package metadata if only resource ordering has changed
- Allow sysadmins to change usernames
- Don't require legacy email addresses to be unique
- Convert logout link to a POST form
- Fix dashboard 'Add Organisation' button so it won't say 'Group'
- Refactor query to improve loading speed of large dashboard news feeds
- Security patching of dependencies