### PR TITLE
[QOLDEV-692] handle missing group_type in activity streams

### DIFF
--- a/ckanext/activity/templates/snippets/stream.html
+++ b/ckanext/activity/templates/snippets/stream.html
@@ -14,6 +14,7 @@
 {% endmacro %}
 
 {% macro organization(activity) %}
+  {% set group_type = group_type or 'organization' %}
   <a href="{{ h.url_for(group_type ~ '.read', id=activity.object_id) }}">
     {{ activity.data.group.title if activity.data.group else _('unknown') }}
   </a>


### PR DESCRIPTION
GitHub #7980 - changes in 2.10.3 to support custom organisation types resulted in the user activity stream crashing if it included any organisation-related entries (because it expects a value that the user stream isn't providing).
