### PR TITLE
[QOLDEV-692] preserve custom org type in user activity streams

### DIFF
--- a/ckanext/activity/templates/snippets/stream.html
+++ b/ckanext/activity/templates/snippets/stream.html
@@ -14,7 +14,7 @@
 {% endmacro %}
 
 {% macro organization(activity) %}
-  {% set group_type = group_type or 'organization' %}
+  {% set group_type = group_type or (activity.data.group.type if (activity.data.group and activity.data.group.type) else 'organization') %}
   <a href="{{ h.url_for(group_type ~ '.read', id=activity.object_id) }}">
     {{ activity.data.group.title if activity.data.group else _('unknown') }}
   </a>


### PR DESCRIPTION
Improve the fix for GitHub #7980 to preserve custom organisation types instead of just falling back to 'organization'.