### PR TITLE
[QOLDEV-692] pass package type through to resource creation activity item

### DIFF
--- a/ckanext/activity/templates/package/snippets/change_item.html
+++ b/ckanext/activity/templates/package/snippets/change_item.html
@@ -4,7 +4,7 @@
 <ul>
   {% for change in changes %}
     {% snippet "snippets/changes/{}.html".format(
-      change.type), change=change %}
+      change.type), change=change, pkg_dict=pkg_dict %}
     <br>
   {% endfor %}
 </ul>

--- a/ckanext/activity/templates/snippets/changes/new_resource.html
+++ b/ckanext/activity/templates/snippets/changes/new_resource.html
@@ -1,4 +1,4 @@
-{% set dataset_type = request.view_args.package_type %}
+{% set dataset_type = request.view_args.package_type or pkg_dict['type'] %}
 {% set pkg_url = h.url_for(dataset_type ~ '.read', id=change.pkg_id) %}
 {% set resource_url = h.url_for(dataset_type ~ '_resource.read', id=change.pkg_id, resource_id = change.resource_id, qualified=True) %}
 


### PR DESCRIPTION
This fixes an internal server error when viewing the Changes screen for the first post-creation update to a dataset, GitHub #8034