### PR TITLE
[QOLSVC-4988] fix email notification checkbox, #8124

### DIFF
--- a/ckanext/activity/templates/user/edit_user_form.html
+++ b/ckanext/activity/templates/user/edit_user_form.html
@@ -2,7 +2,7 @@
 
 {% block extra_fields %}
   {% if h.activity_show_email_notifications() %}
-    {% call form.checkbox('activity_streams_email_notifications', label=_('Subscribe to notification emails'), id='field-activity-streams-email-notifications', value=True, checked=g.userobj.activity_streams_email_notifications) %}
+    {% call form.checkbox('activity_streams_email_notifications', label=_('Subscribe to notification emails'), id='field-activity-streams-email-notifications', value=True, checked=data.activity_streams_email_notifications) %}
       {% set helper_text = _("You will receive notification emails from {site_title}, e.g. when you have new activities on your dashboard."|string) %}
       {{ form.info(helper_text.format(site_title=g.site_title)) }}
     {% endcall %}


### PR DESCRIPTION
- Should be populated from the profile being edited, not from g.userobj. For regular users editing their own profiles it doesn't matter, but when sysadmins edit other profiles it does.
