### PR TITLE
[QOLSVC-6752] shorten lock timeout when dropping a datastore table

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1973,6 +1973,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
         try:
             # check if table exists
             if 'filters' not in data_dict:
+                context['connection'].execute("SET LOCAL lock_timeout = '20s'")
                 context['connection'].execute(
                     u'DROP TABLE "{0}" CASCADE'.format(
                         data_dict['resource_id'])


### PR DESCRIPTION
- If we can't acquire the lock within a reasonable time, then fail instead of deadlocking
