### PR TITLE
[QOLDEV-934] Apply QGOV changes to 2.10.5 base

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,18 @@ Changelog
 
 .. towncrier release notes start
 
+v.2.10.x 2023-xx-xx
+==================
+
+Major features
+--------------
+
+- Update to Interface IUploader, on get_uploader and get_resource_uploader,
+  new to include new method signature metadata() which can be utilised by
+  archiver and other plugins instead of trying on local disk directly
+- Add get API `resource_file_metadata_show` which takes resource ID and returns
+  { 'content_type': content_type, 'size': length, 'hash': hash } if found
+
 v.2.10.5 2024-08-21
 ===================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,22 @@ Major features
   archiver and other plugins instead of trying on local disk directly
 - Add get API `resource_file_metadata_show` which takes resource ID and returns
   { 'content_type': content_type, 'size': length, 'hash': hash } if found
+- Allow sysadmins to edit usernames
+- Add reCAPTCHA checks to logins and password resets
+- Show "Displayed name" instead of "Full name"
+
+Bugfixes
+--------
+
+- Convert dict values into strings before passing to Solr
+- Add '/dataset' fallback when generating URLs
+- Avoid changing package modified timestamp when reordering resources
+- Allow legacy duplicate emails
+- Fix 'groups' vs 'organizations' text on dashboard
+- Invalidate cached pages when cookies change
+- Avoid eagerly loading large CLOB fields on activity dashboard
+- Populate activity stream notification checkbox from the account being edited, not the logged-in user
+- Shorten the lock timeout on dropping datastore tables to avoid deadlocks
 
 v.2.10.5 2024-08-21
 ===================

--- a/ckan/i18n/en_AU/LC_MESSAGES/ckan.po
+++ b/ckan/i18n/en_AU/LC_MESSAGES/ckan.po
@@ -3202,7 +3202,7 @@ msgstr "Change details"
 
 #: ckan/templates/user/edit_user_form.html:13
 msgid "Full name"
-msgstr "Full name"
+msgstr "Displayed name"
 
 #: ckan/templates/user/edit_user_form.html:13
 msgid "eg. Joe Bloggs"
@@ -3374,7 +3374,7 @@ msgstr "username"
 
 #: ckan/templates/user/new_user_form.html:11
 msgid "Full Name"
-msgstr "Full Name"
+msgstr "Displayed Name"
 
 #: ckan/templates/user/new_user_form.html:37
 msgid "Create Account"

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -130,6 +130,8 @@ def _allow_caching(cache_force: Optional[bool] = None):
     elif not config.get('ckan.cache_enabled'):
         allow_cache = False
 
+    # Any rendered template will have a login-sensitive header
+    request.environ['__limit_cache_by_cookie__'] = True
     if not allow_cache:
         # Prevent any further rendering from being cached.
         request.environ['__no_cache__'] = True

--- a/ckan/lib/captcha.py
+++ b/ckan/lib/captcha.py
@@ -7,7 +7,7 @@ from ckan.types import Request
 
 
 def check_recaptcha(request: Request) -> None:
-    '''Check a user\'s recaptcha submission is valid, and raise CaptchaError
+    '''Check a user's recaptcha submission is valid, and raise CaptchaError
     on failure.'''
     recaptcha_private_key = config.get('ckan.recaptcha.privatekey')
     if not recaptcha_private_key:
@@ -17,8 +17,20 @@ def check_recaptcha(request: Request) -> None:
     client_ip_address = request.environ.get(
         'REMOTE_ADDR', 'Unknown IP Address')
 
-    # reCAPTCHA v2
     recaptcha_response_field = request.form.get('g-recaptcha-response', '')
+    check_recaptcha_v2_base(client_ip_address, recaptcha_response_field)
+
+
+def check_recaptcha_v2_base(client_ip_address: str,
+                            recaptcha_response_field: str) -> None:
+    '''Check a user's recaptcha submission is valid, and raise CaptchaError
+    on failure using discreet data'''
+    recaptcha_private_key = config.get('ckan.recaptcha.privatekey', '')
+    if not recaptcha_private_key:
+        # Recaptcha not enabled
+        return
+
+    # reCAPTCHA v2
     recaptcha_server_name = 'https://www.google.com/recaptcha/api/siteverify'
 
     # recaptcha_response_field will be unicode if there are foreign chars in

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -323,6 +323,71 @@ def _get_auto_flask_context():
 
 @core_helper
 def url_for(*args: Any, **kw: Any) -> str:
+    '''Return the URL for an endpoint given some parameters, defaulting to
+    using 'dataset' if the given custom dataset fails.
+
+    This is a wrapper for :py:func:`flask.url_for`
+    and :py:func:`routes.url_for` that adds some extra features that CKAN
+    needs.
+
+    To build a URL for a Flask view, pass the name of the blueprint and the
+    view function separated by a period ``.``, plus any URL parameters::
+        url_for('api.action', ver=3, logic_function='status_show')
+        # Returns /api/3/action/status_show
+
+    For a fully qualified URL pass the ``_external=True`` parameter. This
+    takes the ``ckan.site_url`` and ``ckan.root_path`` settings into account::
+
+        url_for('api.action', ver=3, logic_function='status_show',
+                _external=True)
+
+        # Returns http://example.com/api/3/action/status_show
+
+    URLs built by Pylons use the Routes syntax::
+
+        url_for(controller='my_ctrl', action='my_action', id='my_dataset')
+        # Returns '/dataset/my_dataset'
+
+    Or, using a named route::
+
+        url_for('dataset.read', id='changed')
+        # Returns '/dataset/changed'
+
+    Use ``qualified=True`` for a fully qualified URL when targeting a Pylons
+    endpoint.
+
+    For backwards compatibility, an effort is made to support the Pylons syntax
+    when building a Flask URL, but this support might be dropped in the future,
+    so calls should be updated.
+    '''
+    try:
+        return base_url_for(*args, **kw)
+    except FlaskRouteBuildError:
+        # If the url failed, try again but replace any custom dataset type in
+        #  use with the default 'dataset'
+        retry_with_default = False
+        # Update args if a custom dataset type was set there
+        if (len(args) and '.' in args[0]
+                and not args[0].startswith('/')
+                and not args[0].startswith('dataset.')):
+            args = args[0].split('.', 1)
+            args = ('dataset.' + args[1],)
+            retry_with_default = True
+
+        # Update kw controller if a custom dataset type was set there
+        if (kw.get('controller')
+                and kw.get('controller') != 'dataset'):
+            kw.update({'controller': 'dataset'})
+            retry_with_default = True
+
+        if retry_with_default:
+            return base_url_for(*args, **kw)
+        else:
+            raise
+
+
+@core_helper
+def base_url_for(*args: Any, **kw: Any) -> str:
     '''Return the URL for an endpoint given some parameters.
 
     This is a wrapper for :py:func:`flask.url_for`

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -248,6 +248,9 @@ class PackageSearchIndex(SearchIndex):
                 except DateParserError:
                     log.warning('%r: %r value of %r is not a valid date', pkg_dict['id'], key, value)
                     continue
+            if isinstance(value, dict):
+                # Solr 8+ chokes on passing dict values unless doing an atomic update
+                value = json.dumps(value)
             new_dict[key] = value
 
         pkg_dict = new_dict

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -1,22 +1,25 @@
 # encoding: utf-8
 from __future__ import annotations
 
+import flask
+import hashlib
 import os
 import cgi
 import datetime
 import logging
 import magic
 import mimetypes
+import six
 from typing import Any, IO, Optional, Union
 from urllib.parse import urlparse
 
 from werkzeug.datastructures import FileStorage as FlaskFileStorage
+from werkzeug.wrappers.response import Response as WerkzeugResponse
 
-import ckan.lib.munge as munge
-import ckan.logic as logic
-import ckan.plugins as plugins
+from ckan import logic, plugins
 from ckan.common import config
-from ckan.types import ErrorDict, PUploader, PResourceUploader
+from ckan.lib import base, munge
+from ckan.types import ErrorDict, PUploader, PResourceUploader, Response
 
 ALLOWED_UPLOAD_TYPES = (cgi.FieldStorage, FlaskFileStorage)
 MB = 1 << 20
@@ -96,6 +99,36 @@ def get_max_resource_size() -> int:
     return config.get('ckan.max_resource_size')
 
 
+def _file_hashnlength(local_path: str) -> tuple[str, int]:
+    BLOCKSIZE = 65536
+    hasher = hashlib.sha1()
+    length = 0
+
+    with open(local_path, 'rb') as afile:
+        buf = afile.read(BLOCKSIZE)
+        while len(buf) > 0:
+            hasher.update(buf)
+            length += len(buf)
+
+            buf = afile.read(BLOCKSIZE)
+
+    return (str(hasher.hexdigest()), length)
+
+
+def _add_download_headers(file_path: str,
+                          mime_type: Optional[str],
+                          response: Union[Response, WerkzeugResponse]) -> None:
+    """ Add appropriate 'Content-Type' and 'Content-Disposition' headers
+    to a a file download.
+    """
+    if mime_type:
+        response.headers['Content-Type'] = mime_type
+    if mime_type != 'application/pdf':
+        file_name = file_path.split('/')[-1]
+        response.headers['Content-Disposition'] = \
+            'attachment; filename=' + file_name
+
+
 class Upload(object):
     storage_path: Optional[str]
     filename: Optional[str]
@@ -136,6 +169,13 @@ class Upload(object):
         if old_filename:
             self.old_filepath = os.path.join(self.storage_path, old_filename)
 
+    def _get_storage_path_for(self, filename: str) -> str:
+        '''Function to get the path to a stored file.
+        Storage path must be configured.
+        '''
+        assert self.storage_path
+        return os.path.join(self.storage_path, six.ensure_str(filename))
+
     def update_data_dict(self, data_dict: dict[str, Any], url_field: str,
                          file_field: str, clear_field: str) -> None:
         ''' Manipulate data from the data_dict.  url_field is the name of the
@@ -149,6 +189,7 @@ class Upload(object):
         self.clear = data_dict.pop(clear_field, None)
         self.file_field = file_field
         self.upload_field_storage = data_dict.pop(file_field, None)
+        self.preserve_filename = data_dict.get('preserve_filename', None)
 
         if not self.storage_path:
             return
@@ -156,9 +197,11 @@ class Upload(object):
         if isinstance(self.upload_field_storage, ALLOWED_UPLOAD_TYPES):
             if self.upload_field_storage.filename:
                 self.filename = self.upload_field_storage.filename
-                self.filename = str(datetime.datetime.utcnow()) + self.filename
+                if not self.preserve_filename:
+                    self.filename = str(datetime.datetime.utcnow()) \
+                        + self.filename
                 self.filename = munge.munge_filename_legacy(self.filename)
-                self.filepath = os.path.join(self.storage_path, self.filename)
+                self.filepath = self._get_storage_path_for(self.filename)
                 data_dict[url_field] = self.filename
                 self.upload_file = _get_underlying_file(
                     self.upload_field_storage)
@@ -225,9 +268,42 @@ class Upload(object):
         if types and type_ not in types:
             raise logic.ValidationError(err)
 
+    def delete(self, filename: str) -> None:
+        ''' Delete file we are pointing at'''
+        if self.storage_path and not filename.startswith('http'):
+            try:
+                # Delete file from storage_path and filename
+                os.remove(self._get_storage_path_for(filename))
+            except OSError:
+                pass
+
+    def download(self, filename: str) -> Union[Response, WerkzeugResponse]:
+        ''' Generate file stream or redirect for file'''
+        if not self.storage_path:
+            return base.abort(404, "Uploaded resource not found")
+        filepath = self._get_storage_path_for(filename)
+        resp = flask.send_file(filepath)
+        content_type, _ = mimetypes.guess_type(filepath)
+        _add_download_headers(filepath, content_type, resp)
+        return resp
+
+    def metadata(self, filename: str) -> Union[dict[str, Any], IOError]:
+        ''' Return metadata of file'''
+        if not self.storage_path:
+            return {}
+        try:
+            filepath = self._get_storage_path_for(filename)
+            content_type, _ = mimetypes.guess_type(filepath)
+            hash, length = _file_hashnlength(filepath)
+            return {'content_type': content_type, 'size': length, 'hash': hash}
+        except IOError as e:
+            log.error("Could not retrieve meta data, IOError thrown: %s", e)
+            return e
+
 
 class ResourceUpload(object):
     mimetype: Optional[str]
+    url: Optional[str]
 
     def __init__(self, resource: dict[str, Any]) -> None:
         path = get_storage_path()
@@ -253,6 +329,7 @@ class ResourceUpload(object):
 
         if url and config_mimetype_guess == 'file_ext' and urlparse(url).path:
             self.mimetype = mimetypes.guess_type(url)[0]
+        self.url = url
 
         if bool(upload_field_storage) and \
                 isinstance(upload_field_storage, ALLOWED_UPLOAD_TYPES):
@@ -360,3 +437,37 @@ class ResourceUpload(object):
                 os.remove(filepath)
             except OSError:
                 pass
+
+    def delete(self, id: str, filename: Optional[str] = None) -> None:
+        ''' Delete file we are pointing at'''
+        try:
+            os.remove(self.get_path(id))
+        except OSError:
+            pass
+
+    def download(self, id: str, filename: Optional[str] = None
+                 ) -> Union[Response, WerkzeugResponse]:
+        ''' Generate file stream or redirect for file'''
+        filepath = self.get_path(id)
+        resp = flask.send_file(filepath)
+        _add_download_headers(filepath, self.mimetype, resp)
+        return resp
+
+    def metadata(self,
+                 id: str,
+                 filename: Optional[str] = None
+                 ) -> Union[dict[str, Any], IOError]:
+        ''' Return meta details of file'''
+        try:
+            filepath = self.get_path(id)
+            if self.mimetype:
+                content_type = self.mimetype
+            elif self.url:
+                content_type = mimetypes.guess_type(self.url)[0]
+            else:
+                raise IOError("No resource URL found")
+            hash, length = _file_hashnlength(filepath)
+            return {'content_type': content_type, 'size': length, 'hash': hash}
+        except IOError as e:
+            log.error("Could not retrieve metadata, IOError thrown: %s", e)
+            return e

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -9,12 +9,11 @@ from typing import Any, Union, Type, cast
 
 import sqlalchemy as sqla
 
-import ckan.lib.jobs as jobs
+from ckan.lib import api_token, jobs, uploader
 import ckan.logic
 import ckan.logic.action
 import ckan.logic.schema
 import ckan.plugins as plugins
-import ckan.lib.api_token as api_token
 from ckan import authz
 from  ckan.lib.navl.dictization_functions import validate
 from ckan.model.follower import ModelFollowingModel
@@ -184,6 +183,15 @@ def resource_delete(context: Context, data_dict: DataDict) -> ActionResult.Resou
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.before_resource_delete(context, data_dict,
                                       pkg_dict.get('resources', []))
+
+    # Delete file if it was uploaded
+    if pkg_dict.get('url_type') == 'upload':
+        upload = uploader.get_resource_uploader(pkg_dict)
+        # Don't break if old plugin/interface is found
+        if hasattr(upload, "delete"):
+            upload.delete(id)  # type: ignore
+        else:
+            log.warning("%s does not have delete function, could not cleanup: %s", type(upload).__name__, id)
 
     package_show_context: Union[Context, Any] = dict(context, for_update=True)
     pkg_dict = _get_action('package_show')(

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -16,22 +16,18 @@ from sqlalchemy import text
 
 
 import ckan
+from ckan import logic, model, plugins
 import ckan.lib.dictization
-import ckan.logic as logic
 import ckan.logic.action
 import ckan.logic.schema
 import ckan.lib.dictization.model_dictize as model_dictize
-import ckan.lib.jobs as jobs
+from ckan.lib import datapreview, jobs, plugins as lib_plugins, search, uploader
 import ckan.lib.navl.dictization_functions
-import ckan.model as model
 import ckan.model.misc as misc
-import ckan.plugins as plugins
 import ckan.lib.search as search
 from ckan.model.follower import ModelFollowingModel
 from ckan.lib.search.query import solr_literal
 
-import ckan.lib.plugins as lib_plugins
-import ckan.lib.datapreview as datapreview
 import ckan.authz as authz
 
 from ckan.common import _
@@ -1184,6 +1180,46 @@ def resource_view_list(context: Context,
         if datapreview.get_view_plugin(resource_view.view_type)
     ]
     return model_dictize.resource_view_list_dictize(resource_views, context)
+
+
+def resource_file_metadata_show(
+        context: Context, data_dict: DataDict
+        ) -> Union[dict[str, Any], IOError]:
+    '''Get file metadata from a resource if it was uploaded.
+
+    :param id: the id of the resource
+    :type id: string
+
+    :returns: the meta data of resource file { 'content_type': content_type, 'size': length, 'hash': hash }
+    :rtype: dictionary
+    '''
+    model = context['model']
+    id = _get_or_bust(data_dict, 'id')
+
+    resource = model.Resource.get(id)
+    if not resource:
+        raise NotFound
+    context['resource'] = resource
+
+    _check_access('resource_file_metadata_show', context, data_dict)
+
+    pkg_dict = logic.get_action('package_show')(
+        context,
+        {'id': resource.package.id,
+         'include_tracking': asbool(data_dict.get('include_tracking', False))})
+
+    for resource_dict in pkg_dict['resources']:
+        if resource_dict['id'] == id:
+            break
+    else:
+        log.error('Could not find resource %s after all', id)
+        raise NotFound(_('Resource was not found.'))
+
+    upload = uploader.get_resource_uploader(resource_dict)
+    try:
+        return upload.metadata(id)  # type: ignore
+    except (IOError, AttributeError):
+        raise NotFound
 
 
 def _group_or_org_show(

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -263,6 +263,7 @@ def package_update(
     name_or_id = data_dict.get('id') or data_dict.get('name')
     if name_or_id is None:
         raise ValidationError({'id': _('Missing value')})
+    resources_only = data_dict.pop('resources_only', False)
 
     pkg = model.Package.get(name_or_id)
     if pkg is None:
@@ -317,10 +318,11 @@ def package_update(
         model.Session.rollback()
         raise ValidationError(errors)
 
-    #avoid revisioning by updating directly
-    model.Session.query(model.Package).filter_by(id=pkg.id).update(
-        {"metadata_modified": datetime.datetime.utcnow()})
-    model.Session.refresh(pkg)
+    if not resources_only:
+        #avoid revisioning by updating directly
+        model.Session.query(model.Package).filter_by(id=pkg.id).update(
+            {"metadata_modified": datetime.datetime.utcnow()})
+        model.Session.refresh(pkg)
 
     include_plugin_data = False
     user_obj = context.get('auth_user_obj')
@@ -574,6 +576,7 @@ def package_resource_reorder(
     new_resources = ordered_resources + existing_resources
     package_dict['resources'] = new_resources
 
+    package_dict['resources_only'] = True
     _check_access('package_resource_reorder', context, package_dict)
     _get_action('package_update')(context, package_dict)
 
@@ -791,7 +794,7 @@ def user_update(context: Context, data_dict: DataDict) -> ActionResult.UserUpdat
     '''Update a user account.
 
     Normal users can only update their own user accounts. Sysadmins can update
-    any user account. Can not modify exisiting user's name.
+    any user account and modify existing usernames.
 
     .. note:: Update methods may delete parameters not explicitly provided in the
         data_dict. If you want to edit only a specific attribute use `user_patch`

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -167,6 +167,10 @@ def resource_view_list(context: Context, data_dict: DataDict) -> AuthResult:
     return authz.is_authorized('resource_show', context, data_dict)
 
 
+def resource_file_metadata_show(context: Context, data_dict: DataDict) -> AuthResult:
+    return authz.is_authorized('resource_show', context, data_dict)
+
+
 def group_show(context: Context, data_dict: DataDict) -> AuthResult:
     user = context.get('user')
     group = get_group_object(context, data_dict)

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -615,10 +615,13 @@ def user_name_validator(key: FlattenKey, data: FlattenDataDict,
             return
         else:
             # Otherwise return an error: there's already another user with that
-            # name, so you can create a new user with that name or update an
+            # name, so you can't create a new user with that name or update an
             # existing user's name to that name.
             errors[key].append(_('That login name is not available.'))
     elif user_obj_from_context:
+        requester = context.get('auth_user_obj', None)
+        if requester and requester.sysadmin == True:
+            return
         old_user = model.User.get(user_obj_from_context.id)
         if old_user is not None and old_user.state != model.State.PENDING:
             errors[key].append(_('That login name can not be modified.'))

--- a/ckan/migration/versions/102_ff13667243ed_create_conditinal_index_on_user.py
+++ b/ckan/migration/versions/102_ff13667243ed_create_conditinal_index_on_user.py
@@ -21,7 +21,7 @@ depends_on = None
 def upgrade():
     op.create_index(
         "idx_only_one_active_email", "user", ["email", "state"],
-        unique=True, postgresql_where=sa.text('"user".state=\'active\''))
+        unique=False, postgresql_where=sa.text('"user".state=\'active\''))
 
 
 def downgrade():

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1759,8 +1759,10 @@ class IUploader(Interface):
 
         ``update_data_dict(data_dict, url_field, file_field, clear_field)``
 
-        Allow the data_dict to be manipulated before it reaches any
-        validators.
+        Allow the data_dict to be manipulated before it reaches any validators.
+        Optionally, this data_dict can have the following attribute set:
+        preserve_filename (boolean):  If false, then the current UTC time
+        (datetime.utcnow) will be prepended to the filename.
 
         :param data_dict: data_dict to be updated
         :type data_dict: dictionary
@@ -1783,6 +1785,30 @@ class IUploader(Interface):
         :param max_size: upload size can be limited by this value in MBs.
         :type max_size: int
 
+        ``delete(filename)``
+
+        Perform a delete.
+
+        :param filename: The filename to use when deleting a file,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``download(filename)``
+
+        Provide redirect url or file stream
+
+        :param filename: The filename to use when downloading a file,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``metadata(filename)``
+
+        Collect metadata of file. Returns dict
+        { 'content_type': content_type, 'size': length, 'hash': hash }
+        Throws IOError if file does not exist
+
+        :param filename: The filename to use when collecting metadata
+        :type filename: string
         '''
 
     def get_resource_uploader(
@@ -1821,6 +1847,37 @@ class IUploader(Interface):
         :param id: resource id
         :type id: string
 
+        ``delete(id, filename)``
+
+        Perform a delete.
+
+        :param id: resource id, used to delete file
+        :type id: string
+        :param filename: The filename to use when storing a resource,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``download(id, filename)``
+
+        Provide redirect url or file stream
+
+        :param id: resource id, used to locate file
+        :type id: string
+        :param filename: The filename to use when storing a resource,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``metadata(id, filename)``
+
+        Collect metadata of resource. Returns dict
+        { 'content_type': content_type, 'size': length, 'hash': hash }
+        Throws IOError if file does not exist
+
+        :param id: resource id, used to locate file
+        :type id: string
+        :param filename: The filename to use when collecting metadata,
+            may be None depending on the storage provider.
+        :type filename: string
         '''
 
 

--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -39,10 +39,12 @@
         </li>
         {% endblock %} {% block header_account_log_out_link %}
         <li>
-          <a href="{{ h.url_for('user.logout') }}" title="{{ _('Log out') }}">
-            <i class="fa fa-sign-out" aria-hidden="true"></i>
-            <span class="text">{{ _('Log out') }}</span>
-          </a>
+          <form action="{{ h.url_for('user.logout') }}" method="post">
+            {{ h.csrf_input() }}
+            <button class="btn btn-link" type="submit" title="{{ _('Log out') }}">
+              <i class="fa fa-sign-out" aria-hidden="true"></i>
+            </button>
+          </form>
         </li>
         {% endblock %} {% endblock %}
       </ul>
@@ -98,14 +100,14 @@
               {% set org_type = h.default_group_type('organization') %}
               {% set group_type = h.default_group_type('group') %}
 
-		          {{ h.build_nav_main(
-		            (dataset_type ~ '.search', h.humanize_entity_type('package', dataset_type, 'main nav') or _('Datasets'), ["dataset", "resource"]),
-		            (org_type ~ '.index',
+                  {{ h.build_nav_main(
+                    (dataset_type ~ '.search', h.humanize_entity_type('package', dataset_type, 'main nav') or _('Datasets'), ["dataset", "resource"]),
+                    (org_type ~ '.index',
                   h.humanize_entity_type('organization', org_type, 'main nav') or _('Organizations'), ['organization']),
-		            (group_type ~ '.index',
+                    (group_type ~ '.index',
                   h.humanize_entity_type('group', group_type, 'main nav') or _('Groups'), ['group']),
-		            ('home.about', _('About')) ) }}
-	          {% endblock %}
+                    ('home.about', _('About')) ) }}
+              {% endblock %}
           </ul>
 
       {% endblock %}

--- a/ckan/templates/user/dashboard_organizations.html
+++ b/ckan/templates/user/dashboard_organizations.html
@@ -1,15 +1,13 @@
 {% extends "user/dashboard.html" %}
 
-{% set group_type = h.default_group_type('organization') %}
-
 {% block page_primary_action %}
   {% if h.check_access('organization_create') %}
-    {% link_for h.humanize_entity_type('organization', group_type, 'add link') or _('Add Organization'), named_route=group_type ~ '.new', class_="btn btn-primary", icon="plus-square" %}
+    {% link_for h.humanize_entity_type('organization', org_type, 'add link') or _('Add Organization'), named_route=org_type ~ '.new', class_="btn btn-primary", icon="plus-square" %}
   {% endif %}
 {% endblock %}
 
 {% block primary_content_inner %}
-  <h2 class="hide-heading">{{ h.humanize_entity_type('organization', group_type, 'my label') or _('My Organizations') }}</h2>
+  <h2 class="hide-heading">{{ h.humanize_entity_type('organization', org_type, 'my label') or _('My Organizations') }}</h2>
   {% set organizations = h.organizations_available(permission='manage_group',
     include_dataset_count=True) %}
   {% if organizations %}
@@ -18,9 +16,9 @@
     </div>
   {% else %}
     <p class="empty">
-      {{ h.humanize_entity_type('organization', group_type, 'you not member') or _('You are not a member of any organizations.') }}
+      {{ h.humanize_entity_type('organization', org_type, 'you not member') or _('You are not a member of any organizations.') }}
       {% if h.check_access('organization_create') %}
-        {% link_for _('Create one now?'), named_route=group_type ~ '.new' %}
+        {% link_for _('Create one now?'), named_route=org_type ~ '.new' %}
       {% endif %}
     </p>
   {% endif %}

--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -8,7 +8,11 @@
     {% block core_fields %}
       <fieldset>
         <legend>{{ _('Change details') }}</legend>
-        {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': '', 'class': 'form-control'}) }}
+        {% if g.userobj.sysadmin %}
+          {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], is_required=true) }}
+        {% else %}
+          {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': '', 'class': 'form-control'}) }}
+        {% endif %}
 
         {{ form.input('fullname', label=_('Full name'), id='field-fullname', value=data.fullname, error=errors.fullname, placeholder=_('eg. Joe Bloggs'), classes=['control-medium']) }}
 

--- a/ckan/templates/user/request_reset.html
+++ b/ckan/templates/user/request_reset.html
@@ -18,6 +18,11 @@
             <label for="field-username">{{ _('Email or username') }}</label>
             <input id="field-username" class="control-medium form-control" name="user" value="" type="text" />
           </div>
+
+          {% if g.recaptcha_publickey %}
+            {% snippet "user/snippets/recaptcha.html", public_key=g.recaptcha_publickey %}
+          {% endif %}
+
           <div class="form-actions">
             {% block form_button %}
             <button class="btn btn-primary" type="submit" name="reset">{{ _("Request Reset") }}</button>

--- a/ckan/templates/user/snippets/login_form.html
+++ b/ckan/templates/user/snippets/login_form.html
@@ -24,6 +24,10 @@ Example:
 
   {{ form.checkbox('remember', label=_("Remember me"), id='field-remember', checked=true, value="63072000") }}
 
+  {% if g.recaptcha_publickey %}
+    {% snippet "user/snippets/recaptcha.html", public_key=g.recaptcha_publickey %}
+  {% endif %}
+
   <div class="form-actions">
     {% block login_button %}
     <button class="btn btn-primary" type="submit">{{ _('Login') }}</button>

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -431,6 +431,23 @@ class TestUser(object):
 
         assert "That login name can not be modified" in response
 
+    def test_edit_user_logged_in_username_change_by_sysadmin(
+            self, app, user, sysadmin):
+        env = {"Authorization": sysadmin["token"]}
+
+        response = app.post(
+            url=url_for("user.edit", id=user["id"]),
+            data={
+                "email": user["email"],
+                "save": "",
+                "password1": "",
+                "password2": "",
+                "name": factories.User.stub().name,
+            },
+            extra_environ=env
+        )
+        assert 'Profile updated' in response
+
     def test_perform_reset_for_key_change(self, app):
         password = "TestPassword1"
         params = {"password1": password, "password2": password}

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -49,6 +49,7 @@ def set_cache_control_headers_for_response(response: Response) -> Response:
 
     # __no_cache__ should not be present when caching is allowed
     allow_cache = u'__no_cache__' not in request.environ
+    limit_cache_by_cookie = u'__limit_cache_by_cookie__' in request.environ
 
     if u'Pragma' in response.headers:
         del response.headers["Pragma"]
@@ -63,6 +64,10 @@ def set_cache_control_headers_for_response(response: Response) -> Response:
             pass
     else:
         response.cache_control.private = True
+
+    # Invalidate cached pages upon login/logout
+    if limit_cache_by_cookie:
+        response.vary.add("Cookie")
 
     return response
 

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -170,11 +170,19 @@ def download(package_type: str,
 
     if rsc.get(u'url_type') == u'upload':
         upload = uploader.get_resource_uploader(rsc)
-        filepath = upload.get_path(rsc[u'id'])
-        resp = flask.send_file(filepath, download_name=filename)
+        # Don't break if old plugin/interface is found
+        if hasattr(upload, 'download'):
+            try:
+                resp = upload.download(resource_id, filename)  # type: ignore
+            except (IOError, OSError):
+                # includes FileNotFoundError
+                return base.abort(404, _('Resource data not found'))
+        else:
+            filepath = upload.get_path(rsc[u'id'])
+            resp = flask.send_file(filepath, download_name=filename)
 
-        if rsc.get('mimetype'):
-            resp.headers['Content-Type'] = rsc['mimetype']
+            if rsc.get('mimetype'):
+                resp.headers['Content-Type'] = rsc['mimetype']
         signals.resource_download.send(resource_id)
         return resp
 

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -330,7 +330,8 @@ class EditView(MethodView):
             # getting the identity for current logged user
             identity = {
                 u'login': current_user.name,
-                u'password': data_dict[u'old_password']
+                u'password': data_dict[u'old_password'],
+                u'check_captcha': False
             }
             auth_user = authenticator.ckan_authenticator(identity)
 
@@ -646,6 +647,14 @@ class RequestResetView(MethodView):
 
     def post(self) -> Response:
         self._prepare()
+
+        try:
+            captcha.check_recaptcha(request)
+        except captcha.CaptchaError:
+            error_msg = _(u'Bad Captcha. Please try again.')
+            h.flash_error(error_msg)
+            return h.redirect_to(u'/user/reset')
+
         id = request.form.get(u'user', '')
         if id in (None, u''):
             h.flash_error(_(u'Email is required'))
@@ -938,7 +947,7 @@ user.add_url_rule(
     u'/register', view_func=RegisterView.as_view(str(u'register')))
 
 user.add_url_rule(u'/login', view_func=login, methods=('GET', 'POST'))
-user.add_url_rule(u'/_logout', view_func=logout)
+user.add_url_rule(u'/_logout', view_func=logout, methods=('GET', 'POST'))
 user.add_url_rule(u'/logged_out_redirect', view_func=logged_out_page)
 
 user.add_url_rule(u'/delete/<id>', view_func=delete, methods=(u'POST', 'GET'))

--- a/ckanext/activity/model/activity.py
+++ b/ckanext/activity/model/activity.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 import datetime
-from typing import Any, Optional, Type, TypeVar, cast
+from typing import Any, Optional, Type, TypeVar, Union, List, Tuple, cast
 from typing_extensions import TypeAlias
 
-from sqlalchemy.orm import relationship, backref
+from sqlalchemy.orm import relationship, backref, defer, load_only
 from sqlalchemy import (
     types,
     Column,
@@ -14,6 +14,8 @@ from sqlalchemy import (
     and_,
     union_all,
     text,
+    select,
+    literal,
 )
 
 from ckan.common import config
@@ -49,7 +51,7 @@ class Activity(domain_object.DomainObject, BaseModel):  # type: ignore
     # legacy revision_id values are used by migrate_package_activity.py
     revision_id = Column("revision_id", types.UnicodeText)
     activity_type = Column("activity_type", types.UnicodeText)
-    data = Column("data", _types.JsonDictType)
+    data = Column("data", _types.JsonDictType)  # Big JSON BLOB
 
     activity_detail: "ActivityDetail"
 
@@ -202,16 +204,16 @@ def _activities_limit(
     q: QActivity,
     limit: int,
     offset: Optional[int] = None,
-    revese_order: Optional[bool] = False,
+    reverse_order: Optional[bool] = False,
 ) -> QActivity:
     """
     Return an SQLAlchemy query for all activities at an offset with a limit.
 
-    revese_order:
+    reverse_order:
         if we want the last activities before a date, we must reverse the
         order before limiting.
     """
-    if revese_order:
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -224,6 +226,30 @@ def _activities_limit(
     return q
 
 
+def _activities_defer_data():
+    """
+    This function is used to defer the bulk Data Column from activity lists.
+    defer in sqlalchemy is to not collect data until requested
+    (extra-lazy-load), this can add more round trips if being looked at
+    individually
+    :return: sqlalchemy.orm.defer
+    """
+    return defer(Activity.data)
+
+
+def _activities_load_only_without_data():
+    """
+    This function is used to exclude the bulky Data Column from activity lists.
+
+    The Activity.data column will not be populated nor round trip collected
+
+    :return: sqlalchemy.orm.load_only Object
+    """
+    return load_only(Activity.id, Activity.timestamp, Activity.user_id,
+                     Activity.object_id, Activity.revision_id,
+                     Activity.activity_type)
+
+
 def _activities_union_all(*qlist: QActivity) -> QActivity:
     """
     Return union of two or more activity queries sorted by timestamp,
@@ -231,27 +257,31 @@ def _activities_union_all(*qlist: QActivity) -> QActivity:
     """
     q: QActivity = (
         model.Session.query(Activity)
+        .options(_activities_load_only_without_data())
         .select_entity_from(union_all(*[q.subquery().select() for q in qlist]))
         .distinct(Activity.timestamp)
     )
     return q
 
 
-def _activities_from_user_query(user_id: str) -> QActivity:
+def _activities_from_user_query(user_id: Union[str, List[str]]) -> QActivity:
     """Return an SQLAlchemy query for all activities from user_id."""
     q = model.Session.query(Activity)
-    q = q.filter(Activity.user_id == user_id)
+    q = q.options(_activities_load_only_without_data())
+    q = q.filter(Activity.user_id.in_(_to_list(user_id)))  # type: ignore
     return q
 
 
-def _activities_about_user_query(user_id: str) -> QActivity:
+def _activities_about_user_query(user_id: Union[str, List[str]]) -> QActivity:
     """Return an SQLAlchemy query for all activities about user_id."""
     q = model.Session.query(Activity)
-    q = q.filter(Activity.object_id == user_id)
+    q = q.options(_activities_load_only_without_data())
+    q = q.filter(Activity.object_id.in_(_to_list(user_id)))  # type: ignore
     return q
 
 
-def _user_activity_query(user_id: str, limit: int) -> QActivity:
+def _user_activity_query(
+        user_id: Union[str, List[str]], limit: int) -> QActivity:
     """Return an SQLAlchemy query for all activities from or about user_id."""
     q1 = _activities_limit(_activities_from_user_query(user_id), limit)
     q2 = _activities_limit(_activities_about_user_query(user_id), limit)
@@ -288,8 +318,8 @@ def user_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -303,15 +333,23 @@ def user_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results
 
 
-def _package_activity_query(package_id: str) -> QActivity:
+def _to_list(vals: Union[List[str], Tuple[str], str]):
+    if isinstance(vals, (list, tuple)):
+        return vals
+    return [vals]
+
+
+def _package_activity_query(package_id: Union[str, List[str]]) -> QActivity:
     """Return an SQLAlchemy query for all activities about package_id."""
-    q = model.Session.query(Activity).filter_by(object_id=package_id)
+    q = model.Session.query(Activity) \
+        .options(_activities_defer_data()) \
+        .filter(Activity.object_id.in_(_to_list(package_id)))  # type: ignore
     return q
 
 
@@ -355,8 +393,8 @@ def package_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -370,26 +408,23 @@ def package_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results
 
 
-def _group_activity_query(group_id: str) -> QActivity:
+def _group_activity_query(group_id: Union[str, List[str]]) -> QActivity:
     """Return an SQLAlchemy query for all activities about group_id.
 
     Returns a query for all activities whose object is either the group itself
     or one of the group's datasets.
 
     """
-    group = model.Group.get(group_id)
-    if not group:
-        # Return a query with no results.
-        return model.Session.query(Activity).filter(text("0=1"))
 
+    groups = _to_list(group_id)
     q: QActivity = (
-        model.Session.query(Activity)
+        model.Session.query(Activity).options(_activities_defer_data())
         .outerjoin(model.Member, Activity.object_id == model.Member.table_id)
         .outerjoin(
             model.Package,
@@ -407,20 +442,20 @@ def _group_activity_query(group_id: str) -> QActivity:
             or_(
                 # active dataset in the group
                 and_(
-                    model.Member.group_id == group_id,
+                    model.Member.group_id.in_(groups),  # type: ignore
                     model.Member.state == "active",
                     model.Package.state == "active",
                 ),
                 # deleted dataset in the group
                 and_(
-                    model.Member.group_id == group_id,
+                    model.Member.group_id.in_(groups),  # type: ignore
                     model.Member.state == "deleted",
                     model.Package.state == "deleted",
                 ),
                 # (we want to avoid showing changes to an active dataset that
                 # was once in this group)
                 # activity the the group itself
-                Activity.object_id == group_id,
+                Activity.object_id.in_(groups),  # type: ignore
             )
         )
     )
@@ -438,25 +473,34 @@ def _organization_activity_query(org_id: str) -> QActivity:
     org = model.Group.get(org_id)
     if not org or not org.is_organization:
         # Return a query with no results.
-        return model.Session.query(Activity).filter(text("0=1"))
+        return model.Session.query(Activity)\
+            .options(_activities_defer_data())\
+            .filter(text("0=1"))
 
     q: QActivity = (
         model.Session.query(Activity)
-        .outerjoin(
-            model.Package,
-            and_(
-                model.Package.id == Activity.object_id,
-                model.Package.private == False,  # noqa
-            ),
-        )
+        .options(_activities_defer_data())
         .filter(
             # We only care about activity either on the the org itself or on
             # packages within that org.
             # FIXME: This means that activity that occured while a package
             # belonged to a org but was then removed will not show up. This may
             # not be desired but is consistent with legacy behaviour.
-            or_(
-                model.Package.owner_org == org_id, Activity.object_id == org_id
+            #
+            # Use subselect instead of outer join so that it can all
+            # be indexable
+            Activity.object_id.in_(  # type: ignore
+                select([model.Package.id])  # type: ignore
+                .where(
+                    and_(
+                        model.Package.private == False,  # noqa
+                        model.Package.owner_org == org_id
+                    )
+                )
+                .union(
+                    # select the org itself
+                    select([literal(org_id)])
+                )
             )
         )
     )
@@ -500,8 +544,8 @@ def group_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -515,7 +559,7 @@ def group_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results
@@ -556,8 +600,8 @@ def organization_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -571,7 +615,7 @@ def organization_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results
@@ -586,14 +630,12 @@ def _activities_from_users_followed_by_user_query(
     follower_objects = model.UserFollowingUser.followee_list(user_id)
     if not follower_objects:
         # Return a query with no results.
-        return model.Session.query(Activity).filter(text("0=1"))
+        return model.Session.query(Activity)\
+            .options(_activities_load_only_without_data()).filter(text("0=1"))
 
-    return _activities_union_all(
-        *[
-            _user_activity_query(follower.object_id, limit)
-            for follower in follower_objects
-        ]
-    )
+    return _user_activity_query(
+        [follower.object_id for follower in follower_objects],
+        limit)
 
 
 def _activities_from_datasets_followed_by_user_query(
@@ -604,16 +646,13 @@ def _activities_from_datasets_followed_by_user_query(
     follower_objects = model.UserFollowingDataset.followee_list(user_id)
     if not follower_objects:
         # Return a query with no results.
-        return model.Session.query(Activity).filter(text("0=1"))
+        return model.Session.query(Activity)\
+            .options(_activities_load_only_without_data()).filter(text("0=1"))
 
-    return _activities_union_all(
-        *[
-            _activities_limit(
-                _package_activity_query(follower.object_id), limit
-            )
-            for follower in follower_objects
-        ]
-    )
+    return _activities_limit(
+        _package_activity_query(
+            [follower.object_id for follower in follower_objects]),
+        limit)
 
 
 def _activities_from_groups_followed_by_user_query(
@@ -630,14 +669,13 @@ def _activities_from_groups_followed_by_user_query(
     follower_objects = model.UserFollowingGroup.followee_list(user_id)
     if not follower_objects:
         # Return a query with no results.
-        return model.Session.query(Activity).filter(text("0=1"))
+        return model.Session.query(Activity)\
+            .options(_activities_load_only_without_data()).filter(text("0=1"))
 
-    return _activities_union_all(
-        *[
-            _activities_limit(_group_activity_query(follower.object_id), limit)
-            for follower in follower_objects
-        ]
-    )
+    return _activities_limit(
+        _group_activity_query(
+            [follower.object_id for follower in follower_objects]),
+        limit)
 
 
 def _activities_from_everything_followed_by_user_query(
@@ -698,8 +736,8 @@ def dashboard_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -713,7 +751,7 @@ def dashboard_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results
@@ -726,8 +764,9 @@ def _changed_packages_activity_query() -> QActivity:
     'new_package', 'changed_package', 'deleted_package'.
 
     """
-    q = model.Session.query(Activity)
-    q = q.filter(Activity.activity_type.endswith("package"))
+    q = model.Session.query(Activity) \
+        .options(_activities_defer_data()) \
+        .filter(Activity.activity_type.endswith("package"))
     return q
 
 

--- a/ckanext/activity/templates/user/edit_user_form.html
+++ b/ckanext/activity/templates/user/edit_user_form.html
@@ -2,7 +2,7 @@
 
 {% block extra_fields %}
   {% if h.activity_show_email_notifications() %}
-    {% call form.checkbox('activity_streams_email_notifications', label=_('Subscribe to notification emails'), id='field-activity-streams-email-notifications', value=True, checked=g.userobj.activity_streams_email_notifications) %}
+    {% call form.checkbox('activity_streams_email_notifications', label=_('Subscribe to notification emails'), id='field-activity-streams-email-notifications', value=True, checked=data.activity_streams_email_notifications) %}
       {% set helper_text = _("You will receive notification emails from {site_title}, e.g. when you have new activities on your dashboard."|string) %}
       {{ form.info(helper_text.format(site_title=g.site_title)) }}
     {% endcall %}

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1973,6 +1973,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
         try:
             # check if table exists
             if 'filters' not in data_dict:
+                context['connection'].execute("SET LOCAL lock_timeout = '20s'")
                 context['connection'].execute(
                     u'DROP TABLE "{0}" CASCADE'.format(
                         data_dict['resource_id'])

--- a/ckanext/datatablesview/public/vendor/DataTables/i18n/en_AU.json
+++ b/ckanext/datatablesview/public/vendor/DataTables/i18n/en_AU.json
@@ -1,0 +1,178 @@
+{
+    "emptyTable": "No data available in table",
+    "info": "Showing _START_ to _END_ of _TOTAL_ entries",
+    "infoEmpty": "Showing 0 to 0 of 0 entries",
+    "infoFiltered": "(filtered from _MAX_ total entries)",
+    "infoThousands": ",",
+    "lengthMenu": "Show _MENU_ entries",
+    "loadingRecords": "Loading...",
+    "processing": "Processing...",
+    "search": "Search:",
+    "zeroRecords": "No matching records found",
+    "thousands": ",",
+    "paginate": {
+        "first": "First",
+        "last": "Last",
+        "next": "Next",
+        "previous": "Previous"
+    },
+    "aria": {
+        "sortAscending": ": activate to sort column ascending",
+        "sortDescending": ": activate to sort column descending"
+    },
+    "autoFill": {
+        "cancel": "Cancel",
+        "fill": "Fill all cells with <i>%d<\/i>",
+        "fillHorizontal": "Fill cells horizontally",
+        "fillVertical": "Fill cells vertically"
+    },
+    "buttons": {
+        "collection": "Collection <span class='ui-button-icon-primary ui-icon ui-icon-triangle-1-s'\/>",
+        "colvis": "Column Visibility",
+        "colvisRestore": "Restore visibility",
+        "copy": "Copy",
+        "copyKeys": "Press ctrl or u2318 + C to copy the table data to your system clipboard.<br><br>To cancel, click this message or press escape.",
+        "copySuccess": {
+            "1": "Copied 1 row to clipboard",
+            "_": "Copied %d rows to clipboard"
+        },
+        "copyTitle": "Copy to Clipboard",
+        "csv": "CSV",
+        "excel": "Excel",
+        "pageLength": {
+            "-1": "Show all rows",
+            "1": "Show 1 row",
+            "_": "Show %d rows"
+        },
+        "pdf": "PDF",
+        "print": "Print"
+    },
+    "searchBuilder": {
+        "add": "Add Condition",
+        "button": {
+            "0": "Search Builder",
+            "_": "Search Builder (%d)"
+        },
+        "clearAll": "Clear All",
+        "condition": "Condition",
+        "conditions": {
+            "date": {
+                "after": "After",
+                "before": "Before",
+                "between": "Between",
+                "empty": "Empty",
+                "equals": "Equals",
+                "not": "Not",
+                "notBetween": "Not Between",
+                "notEmpty": "Not Empty"
+            },
+            "number": {
+                "between": "Between",
+                "empty": "Empty",
+                "equals": "Equals",
+                "gt": "Greater Than",
+                "gte": "Greater Than Equal To",
+                "lt": "Less Than",
+                "lte": "Less Than Equal To",
+                "not": "Not",
+                "notBetween": "Not Between",
+                "notEmpty": "Not Empty"
+            },
+            "string": {
+                "contains": "Contains",
+                "empty": "Empty",
+                "endsWith": "Ends With",
+                "equals": "Equals",
+                "not": "Not",
+                "notEmpty": "Not Empty",
+                "startsWith": "Starts With"
+            },
+            "array": {
+                "without": "Without",
+                "notEmpty": "Not Empty",
+                "not": "Not",
+                "contains": "Contains",
+                "empty": "Empty",
+                "equals": "Equals"
+            }
+        },
+        "data": "Data",
+        "deleteTitle": "Delete filtering rule",
+        "leftTitle": "Outdent Criteria",
+        "logicAnd": "And",
+        "logicOr": "Or",
+        "rightTitle": "Indent Criteria",
+        "title": {
+            "0": "Search Builder",
+            "_": "Search Builder (%d)"
+        },
+        "value": "Value"
+    },
+    "searchPanes": {
+        "clearMessage": "Clear All",
+        "collapse": {
+            "0": "SearchPanes",
+            "_": "SearchPanes (%d)"
+        },
+        "count": "{total}",
+        "countFiltered": "{shown} ({total})",
+        "emptyPanes": "No SearchPanes",
+        "loadMessage": "Loading SearchPanes",
+        "title": "Filters Active - %d"
+    },
+    "select": {
+        "1": "%d row selected",
+        "_": "%d rows selected",
+        "cells": {
+            "1": "1 cell selected",
+            "_": "%d cells selected"
+        },
+        "columns": {
+            "1": "1 column selected",
+            "_": "%d columns selected"
+        }
+    },
+    "datetime": {
+        "previous": "Previous",
+        "next": "Next",
+        "hours": "Hour",
+        "minutes": "Minute",
+        "seconds": "Second",
+        "unknown": "-",
+        "amPm": [
+            "am",
+            "pm"
+        ]
+    },
+    "editor": {
+        "close": "Close",
+        "create": {
+            "button": "New",
+            "title": "Create new entry",
+            "submit": "Create"
+        },
+        "edit": {
+            "button": "Edit",
+            "title": "Edit Entry",
+            "submit": "Update"
+        },
+        "remove": {
+            "button": "Delete",
+            "title": "Delete",
+            "submit": "Delete",
+            "confirm": {
+                "_": "Are you sure you wish to delete %d rows?",
+                "1": "Are you sure you wish to delete 1 row?"
+            }
+        },
+        "error": {
+            "system": "A system error has occurred (<a target=\"\\\" rel=\"nofollow\" href=\"\\\">More information<\/a>)."
+        },
+        "multi": {
+            "title": "Multiple Values",
+            "info": "The selected items contain different values for this input. To edit and set all items for this input to the same value, click or tap here, otherwise they will retain their individual values.",
+            "restore": "Undo Changes",
+            "noMulti": "This input can be edited individually, but not part of a group. "
+        }
+    }
+}

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/dev-requirements.txt
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/dev-requirements.txt
@@ -1,1 +1,2 @@
 pytest-ckan
+zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -25,3 +25,10 @@ pytest-factoryboy==2.4.0
 pytest-freezegun==0.4.2
 pytest-rerunfailures==10.2
 pytest-split==0.8.0
+certifi>=2024.7.4 # not directly required, pinned by Snyk to avoid a vulnerability
+idna>=3.7 # not directly required, pinned by Snyk to avoid a vulnerability
+ipython>=7.16.3 # not directly required, pinned by Snyk to avoid a vulnerability
+prompt-toolkit>=3.0.13 # not directly required, pinned by Snyk to avoid a vulnerability
+pygments>=2.15.0 # not directly required, pinned by Snyk to avoid a vulnerability
+requests>=2.31.0 # not directly required, pinned by Snyk to avoid a vulnerability
+urllib3>=1.26.19 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,15 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@fortawesome/fontawesome-free": "^6.0.0",
-        "@highlightjs/cdn-assets": "^11.5.0",
-        "@popperjs/core": "^2.10.2",
+        "@fortawesome/fontawesome-free": "^6.5.2",
+        "@highlightjs/cdn-assets": "^11.9.0",
+        "@popperjs/core": "^2.11.8",
         "blueimp-file-upload": "^10.32.0",
-        "bootstrap": "^5.1.3",
-        "dompurify": "^2.3.3",
+        "bootstrap": "^5.3.3",
+        "dompurify": "^3.1.1",
         "jquery": "^3.6.0",
         "moment": "^2.29.4",
-        "qs": "^6.10.3"
+        "qs": "^6.12.1"
       },
       "devDependencies": {
         "axe-core": "^4.4.1",
@@ -97,10 +97,9 @@
       "dev": true
     },
     "node_modules/@fortawesome/fontawesome-free": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.0.0.tgz",
-      "integrity": "sha512-6LB4PYBST1Rx40klypw1SmSDArjFOcfBf2LeX9Zg5EKJT2eXiyiJq+CyBYKeXyK0sXS2FsCJWSPr/luyhuvh0Q==",
-      "hasInstallScript": true,
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.6.0.tgz",
+      "integrity": "sha512-60G28ke/sXdtS9KZCpZSHHkCbdsOGEhIUGlwq6yhY74UpTiToIh8np7A8yphhM4BWsvNFtIvLpi4co+h9Mr9Ow==",
       "engines": {
         "node": ">=6"
       }
@@ -135,17 +134,21 @@
       }
     },
     "node_modules/@highlightjs/cdn-assets": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@highlightjs/cdn-assets/-/cdn-assets-11.5.0.tgz",
-      "integrity": "sha512-FvHZ1DVpkjoq6uhRbjkZ44TFIba0vLZkI7J6ZqiRq4QIVSQGuEUbblnL9zU+do+RDm2NhvAGu0KJ8w1xzThnXA==",
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/@highlightjs/cdn-assets/-/cdn-assets-11.10.0.tgz",
+      "integrity": "sha512-vWXpu+Rdm0YMJmugFdUiL/9DmgYjEiV+d5DBqlXdApnGPSIeo6+LRS5Hpx6fvVsKkvR4RsLYD9rQ6DOLkj7OKA==",
       "engines": {
         "node": ">=12.0.0"
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
-      "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ=="
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
     },
     "node_modules/@types/node": {
       "version": "14.17.21",
@@ -642,15 +645,21 @@
       "optional": true
     },
     "node_modules/bootstrap": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
-      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
       "peerDependencies": {
-        "@popperjs/core": "^2.10.2"
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/brace-expansion": {
@@ -756,12 +765,21 @@
       "dev": true
     },
     "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/camelcase": {
@@ -1398,6 +1416,22 @@
       "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
       "dev": true
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -1468,9 +1502,9 @@
       "dev": true
     },
     "node_modules/dompurify": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.3.tgz",
-      "integrity": "sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg=="
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
+      "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="
     },
     "node_modules/duplexify": {
       "version": "3.7.1",
@@ -1541,6 +1575,25 @@
       "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es5-ext": {
@@ -2021,9 +2074,12 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "1.0.3",
@@ -2032,13 +2088,21 @@
       "dev": true
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-stream": {
@@ -2210,6 +2274,17 @@
         "sparkles": "^1.0.0"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -2365,24 +2440,44 @@
         "glogg": "^1.0.0"
       }
     },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/has-value": {
       "version": "1.0.0",
@@ -2412,6 +2507,17 @@
       "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/homedir-polyfill": {
@@ -3370,9 +3476,15 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
@@ -3721,11 +3833,11 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -4111,6 +4223,22 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/set-value": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -4148,13 +4276,20 @@
       "dev": true
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -5102,9 +5237,9 @@
       }
     },
     "@fortawesome/fontawesome-free": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.0.0.tgz",
-      "integrity": "sha512-6LB4PYBST1Rx40klypw1SmSDArjFOcfBf2LeX9Zg5EKJT2eXiyiJq+CyBYKeXyK0sXS2FsCJWSPr/luyhuvh0Q=="
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.6.0.tgz",
+      "integrity": "sha512-60G28ke/sXdtS9KZCpZSHHkCbdsOGEhIUGlwq6yhY74UpTiToIh8np7A8yphhM4BWsvNFtIvLpi4co+h9Mr9Ow=="
     },
     "@gulp-sourcemaps/identity-map": {
       "version": "1.0.2",
@@ -5138,14 +5273,14 @@
       }
     },
     "@highlightjs/cdn-assets": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@highlightjs/cdn-assets/-/cdn-assets-11.5.0.tgz",
-      "integrity": "sha512-FvHZ1DVpkjoq6uhRbjkZ44TFIba0vLZkI7J6ZqiRq4QIVSQGuEUbblnL9zU+do+RDm2NhvAGu0KJ8w1xzThnXA=="
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/@highlightjs/cdn-assets/-/cdn-assets-11.10.0.tgz",
+      "integrity": "sha512-vWXpu+Rdm0YMJmugFdUiL/9DmgYjEiV+d5DBqlXdApnGPSIeo6+LRS5Hpx6fvVsKkvR4RsLYD9rQ6DOLkj7OKA=="
     },
     "@popperjs/core": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
-      "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ=="
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@types/node": {
       "version": "14.17.21",
@@ -5624,9 +5759,9 @@
       "optional": true
     },
     "bootstrap": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
-      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
       "requires": {}
     },
     "brace-expansion": {
@@ -5720,12 +5855,15 @@
       "dev": true
     },
     "call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
       }
     },
     "camelcase": {
@@ -6334,6 +6472,16 @@
       "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
       "dev": true
     },
+    "define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "requires": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      }
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -6403,9 +6551,9 @@
       "dev": true
     },
     "dompurify": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.3.tgz",
-      "integrity": "sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg=="
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
+      "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="
     },
     "duplexify": {
       "version": "3.7.1",
@@ -6479,6 +6627,19 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "requires": {
+        "get-intrinsic": "^1.2.4"
+      }
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
     },
     "es5-ext": {
       "version": "0.10.53",
@@ -6958,9 +7119,9 @@
       }
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -6969,13 +7130,15 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
       }
     },
     "get-stream": {
@@ -7149,6 +7312,14 @@
         "sparkles": "^1.0.0"
       }
     },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "requires": {
+        "get-intrinsic": "^1.1.3"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -7306,24 +7477,29 @@
         "glogg": "^1.0.0"
       }
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
+    "has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "requires": {
+        "es-define-property": "^1.0.0"
+      }
+    },
+    "has-proto": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q=="
+    },
     "has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
     "has-value": {
       "version": "1.0.0",
@@ -7355,6 +7531,14 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "requires": {
+        "function-bind": "^1.1.2"
       }
     },
     "homedir-polyfill": {
@@ -8299,9 +8483,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -8640,11 +8824,11 @@
       "dev": true
     },
     "qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "requires": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       }
     },
     "read-pkg": {
@@ -9018,6 +9202,19 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
+    "set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "requires": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      }
+    },
     "set-value": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -9057,13 +9254,14 @@
       "dev": true
     },
     "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
       "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
       }
     },
     "signal-exit": {

--- a/package.json
+++ b/package.json
@@ -3,15 +3,15 @@
   "version": "1.0.0",
   "description": "CKAN: The Open Source Data Portal Software ==========================================",
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^6.0.0",
-    "@highlightjs/cdn-assets": "^11.5.0",
-    "@popperjs/core": "^2.10.2",
+    "@fortawesome/fontawesome-free": "^6.5.2",
+    "@highlightjs/cdn-assets": "^11.9.0",
+    "@popperjs/core": "^2.11.8",
     "blueimp-file-upload": "^10.32.0",
-    "bootstrap": "^5.1.3",
-    "dompurify": "^2.3.3",
+    "bootstrap": "^5.3.3",
+    "dompurify": "^3.1.1",
     "jquery": "^3.6.0",
     "moment": "^2.29.4",
-    "qs": "^6.10.3"
+    "qs": "^6.12.1"
   },
   "devDependencies": {
     "axe-core": "^4.4.1",


### PR DESCRIPTION
- Add reCAPTCHA to logins
- Show 'Displayed name' instead of 'Full name' as it better matches the field's nature
- Add more uploader functions to support plugins such as Archiver
- Add '/dataset' fallback to URL generation
- Convert dict values into strings before passing to Solr
- Avoid changing package modified timestamp when reordering resources
- Allow sysadmins to edit usernames
- Allow legacy duplicate emails
- Use POST for logouts to avoid caching
- Fix 'group' vs 'organization' text on dashboard
- Invalidate cached pages when cookies change
- Avoid eagerly loading large CLOB fields on activity dashboard
- Populate activity stream notification checkbox from the account being edited, not the logged-in user
- Shorten the lock timeout on dropping datastore tables to avoid deadlocks
- Patch dependencies