### PR TITLE
QOLDEV-955 apply QGOV changes to 2.11 base

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -60,13 +60,13 @@ jobs:
         with:
           start: ckan -c test-core-cypress.ini run
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: cypress-videos

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,29 @@ Changelog
 
 .. towncrier release notes start
 
+v.2.11.x 2025-xx-xx
+==================
+
+Major features
+--------------
+
+- Update to Interface IUploader, on get_uploader and get_resource_uploader,
+  new to include new method signature metadata() which can be utilised by
+  archiver and other plugins instead of trying on local disk directly
+- Add get API `resource_file_metadata_show` which takes resource ID and returns
+  { 'content_type': content_type, 'size': length, 'hash': hash } if found
+- Show "Displayed name" instead of "Full name"
+- Add 'en_AU' locale to DataTables
+
+Bugfixes
+--------
+
+- Convert dict values into strings before passing to Solr
+- Add '/dataset' fallback when generating URLs
+- Avoid changing package modified timestamp when reordering resources
+- Invalidate cached pages when cookies change
+- Shorten the lock timeout on dropping datastore tables to avoid deadlocks
+
 v.2.11.1 2024-12-11
 ===================
 

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -326,7 +326,7 @@ groups:
         default: 31_536_000 # 1 year
         description: |
           If :ref:`SESSION_PERMANENT` is enabled, the session’s expiration will be
-          set this number of seconds in the future. Note that you can not set a 
+          set this number of seconds in the future. Note that you can not set a
           session that never expires (only very far into the future).
 
       - key: SESSION_USE_SIGNER
@@ -624,6 +624,19 @@ groups:
           but unauthorised requests will receive HTTP 403 Forbidden.
           If False, all unauthorised requests will receive HTTP 404 Not Found.
           Default is False.
+
+      - key: ckan.auth.reveal_deleted_datasets
+        type: bool
+        default: True
+        description: |
+          Determines whether unauthorised requests for deleted datasets should have
+          the existence of the datasets revealed (True) or hidden (False).
+          This behaves similarly to ckan.auth.reveal_private_datasets; True gives
+          either HTTP 403 Forbidden (if logged in) or a redirect to the login page,
+          while False gives HTTP 404 Not Found. However, it will only take effect
+          if ckan.auth.reveal_private_datasets is already True; otherwise,
+          return HTTP 404 on unauthorised requests regardless of this value.
+          Default is True.
 
       - key: ckan.auth.enable_cookie_auth_in_api
         type: bool

--- a/ckan/i18n/en_AU/LC_MESSAGES/ckan.po
+++ b/ckan/i18n/en_AU/LC_MESSAGES/ckan.po
@@ -2,10 +2,10 @@
 # Copyright (C) 2024 ORGANIZATION
 # This file is distributed under the same license as the ckan project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
-# 
+#
 # Translators:
 # Adrià Mercader <amercadero@gmail.com>, 2024
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
@@ -3132,7 +3132,7 @@ msgstr "Change details"
 
 #: ckan/templates/user/edit_user_form.html:17
 msgid "Full name"
-msgstr "Full name"
+msgstr "Displayed name"
 
 #: ckan/templates/user/edit_user_form.html:17
 msgid "eg. Joe Bloggs"
@@ -3304,7 +3304,7 @@ msgstr "username"
 
 #: ckan/templates/user/new_user_form.html:11
 msgid "Full Name"
-msgstr "Full Name"
+msgstr "Displayed Name"
 
 #: ckan/templates/user/new_user_form.html:37
 msgid "Create Account"

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -127,6 +127,8 @@ def _allow_caching(cache_force: Optional[bool] = None):
     elif not config.get('ckan.cache_enabled'):
         allow_cache = False
 
+    # Any rendered template will have a login-sensitive header
+    request.environ['__limit_cache_by_cookie__'] = True
     if not allow_cache:
         # Prevent any further rendering from being cached.
         request.environ['__no_cache__'] = True

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -326,6 +326,71 @@ def _get_auto_flask_context():
 
 @core_helper
 def url_for(*args: Any, **kw: Any) -> str:
+    '''Return the URL for an endpoint given some parameters, defaulting to
+    using 'dataset' if the given custom dataset fails.
+
+    This is a wrapper for :py:func:`flask.url_for`
+    and :py:func:`routes.url_for` that adds some extra features that CKAN
+    needs.
+
+    To build a URL for a Flask view, pass the name of the blueprint and the
+    view function separated by a period ``.``, plus any URL parameters::
+        url_for('api.action', ver=3, logic_function='status_show')
+        # Returns /api/3/action/status_show
+
+    For a fully qualified URL pass the ``_external=True`` parameter. This
+    takes the ``ckan.site_url`` and ``ckan.root_path`` settings into account::
+
+        url_for('api.action', ver=3, logic_function='status_show',
+                _external=True)
+
+        # Returns http://example.com/api/3/action/status_show
+
+    URLs built by Pylons use the Routes syntax::
+
+        url_for(controller='my_ctrl', action='my_action', id='my_dataset')
+        # Returns '/dataset/my_dataset'
+
+    Or, using a named route::
+
+        url_for('dataset.read', id='changed')
+        # Returns '/dataset/changed'
+
+    Use ``qualified=True`` for a fully qualified URL when targeting a Pylons
+    endpoint.
+
+    For backwards compatibility, an effort is made to support the Pylons syntax
+    when building a Flask URL, but this support might be dropped in the future,
+    so calls should be updated.
+    '''
+    try:
+        return base_url_for(*args, **kw)
+    except FlaskRouteBuildError:
+        # If the url failed, try again but replace any custom dataset type in
+        #  use with the default 'dataset'
+        retry_with_default = False
+        # Update args if a custom dataset type was set there
+        if (len(args) and '.' in args[0]
+                and not args[0].startswith('/')
+                and not args[0].startswith('dataset.')):
+            args = args[0].split('.', 1)
+            args = ('dataset.' + args[1],)
+            retry_with_default = True
+
+        # Update kw controller if a custom dataset type was set there
+        if (kw.get('controller')
+                and kw.get('controller') != 'dataset'):
+            kw.update({'controller': 'dataset'})
+            retry_with_default = True
+
+        if retry_with_default:
+            return base_url_for(*args, **kw)
+        else:
+            raise
+
+
+@core_helper
+def base_url_for(*args: Any, **kw: Any) -> str:
     '''Return the URL for an endpoint given some parameters.
 
     This is a wrapper for :py:func:`flask.url_for`

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -236,6 +236,9 @@ class PackageSearchIndex(SearchIndex):
                 except DateParserError:
                     log.warning('%r: %r value of %r is not a valid date', pkg_dict['id'], key, value)
                     continue
+            if isinstance(value, dict):
+                # Solr 8+ chokes on passing dict values unless doing an atomic update
+                value = json.dumps(value)
             new_dict[key] = value
 
         pkg_dict = new_dict

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -189,6 +189,7 @@ class Upload(object):
         self.clear = data_dict.pop(clear_field, None)
         self.file_field = file_field
         self.upload_field_storage = data_dict.pop(file_field, None)
+        self.preserve_filename = data_dict.get('preserve_filename', None)
 
         if not self.storage_path:
             return
@@ -196,7 +197,9 @@ class Upload(object):
         if isinstance(self.upload_field_storage, ALLOWED_UPLOAD_TYPES):
             if self.upload_field_storage.filename:
                 self.filename = self.upload_field_storage.filename
-                self.filename = str(datetime.datetime.utcnow()) + self.filename
+                if not self.preserve_filename:
+                    self.filename = str(datetime.datetime.utcnow()) \
+                        + self.filename
                 self.filename = munge.munge_filename_legacy(self.filename)
                 self.filepath = self._get_storage_path_for(self.filename)
                 data_dict[url_field] = self.filename

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -1,22 +1,25 @@
 # encoding: utf-8
 from __future__ import annotations
 
+import flask
+import hashlib
 import os
 import cgi
 import datetime
 import logging
 import magic
 import mimetypes
+import six
 from typing import Any, IO, Optional, Union
 from urllib.parse import urlparse
 
 from werkzeug.datastructures import FileStorage as FlaskFileStorage
+from werkzeug.wrappers.response import Response as WerkzeugResponse
 
-import ckan.lib.munge as munge
-import ckan.logic as logic
-import ckan.plugins as plugins
+from ckan import logic, plugins
 from ckan.common import config
-from ckan.types import ErrorDict, PUploader, PResourceUploader
+from ckan.lib import base, munge
+from ckan.types import ErrorDict, PUploader, PResourceUploader, Response
 
 ALLOWED_UPLOAD_TYPES = (cgi.FieldStorage, FlaskFileStorage)
 MB = 1 << 20
@@ -96,6 +99,36 @@ def get_max_resource_size() -> int:
     return config.get('ckan.max_resource_size')
 
 
+def _file_hashnlength(local_path: str) -> tuple[str, int]:
+    BLOCKSIZE = 65536
+    hasher = hashlib.sha1()
+    length = 0
+
+    with open(local_path, 'rb') as afile:
+        buf = afile.read(BLOCKSIZE)
+        while len(buf) > 0:
+            hasher.update(buf)
+            length += len(buf)
+
+            buf = afile.read(BLOCKSIZE)
+
+    return (str(hasher.hexdigest()), length)
+
+
+def _add_download_headers(file_path: str,
+                          mime_type: Optional[str],
+                          response: Union[Response, WerkzeugResponse]) -> None:
+    """ Add appropriate 'Content-Type' and 'Content-Disposition' headers
+    to a a file download.
+    """
+    if mime_type:
+        response.headers['Content-Type'] = mime_type
+    if mime_type != 'application/pdf':
+        file_name = file_path.split('/')[-1]
+        response.headers['Content-Disposition'] = \
+            'attachment; filename=' + file_name
+
+
 class Upload(object):
     storage_path: Optional[str]
     filename: Optional[str]
@@ -136,6 +169,13 @@ class Upload(object):
         if old_filename:
             self.old_filepath = os.path.join(self.storage_path, old_filename)
 
+    def _get_storage_path_for(self, filename: str) -> str:
+        '''Function to get the path to a stored file.
+        Storage path must be configured.
+        '''
+        assert self.storage_path
+        return os.path.join(self.storage_path, six.ensure_str(filename))
+
     def update_data_dict(self, data_dict: dict[str, Any], url_field: str,
                          file_field: str, clear_field: str) -> None:
         ''' Manipulate data from the data_dict.  url_field is the name of the
@@ -158,7 +198,7 @@ class Upload(object):
                 self.filename = self.upload_field_storage.filename
                 self.filename = str(datetime.datetime.utcnow()) + self.filename
                 self.filename = munge.munge_filename_legacy(self.filename)
-                self.filepath = os.path.join(self.storage_path, self.filename)
+                self.filepath = self._get_storage_path_for(self.filename)
                 data_dict[url_field] = self.filename
                 self.upload_file = _get_underlying_file(
                     self.upload_field_storage)
@@ -225,9 +265,42 @@ class Upload(object):
         if types and type_ not in types:
             raise logic.ValidationError(err)
 
+    def delete(self, filename: str) -> None:
+        ''' Delete file we are pointing at'''
+        if self.storage_path and not filename.startswith('http'):
+            try:
+                # Delete file from storage_path and filename
+                os.remove(self._get_storage_path_for(filename))
+            except OSError:
+                pass
+
+    def download(self, filename: str) -> Union[Response, WerkzeugResponse]:
+        ''' Generate file stream or redirect for file'''
+        if not self.storage_path:
+            return base.abort(404, "Uploaded resource not found")
+        filepath = self._get_storage_path_for(filename)
+        resp = flask.send_file(filepath)
+        content_type, _ = mimetypes.guess_type(filepath)
+        _add_download_headers(filepath, content_type, resp)
+        return resp
+
+    def metadata(self, filename: str) -> Union[dict[str, Any], IOError]:
+        ''' Return metadata of file'''
+        if not self.storage_path:
+            return {}
+        try:
+            filepath = self._get_storage_path_for(filename)
+            content_type, _ = mimetypes.guess_type(filepath)
+            hash, length = _file_hashnlength(filepath)
+            return {'content_type': content_type, 'size': length, 'hash': hash}
+        except IOError as e:
+            log.error("Could not retrieve meta data, IOError thrown: %s", e)
+            return e
+
 
 class ResourceUpload(object):
     mimetype: Optional[str]
+    url: Optional[str]
 
     def __init__(self, resource: dict[str, Any]) -> None:
         path = get_storage_path()
@@ -253,6 +326,7 @@ class ResourceUpload(object):
 
         if url and config_mimetype_guess == 'file_ext' and urlparse(url).path:
             self.mimetype = mimetypes.guess_type(url)[0]
+        self.url = url
 
         if bool(upload_field_storage) and \
                 isinstance(upload_field_storage, ALLOWED_UPLOAD_TYPES):
@@ -360,3 +434,37 @@ class ResourceUpload(object):
                 os.remove(filepath)
             except OSError:
                 pass
+
+    def delete(self, id: str, filename: Optional[str] = None) -> None:
+        ''' Delete file we are pointing at'''
+        try:
+            os.remove(self.get_path(id))
+        except OSError:
+            pass
+
+    def download(self, id: str, filename: Optional[str] = None
+                 ) -> Union[Response, WerkzeugResponse]:
+        ''' Generate file stream or redirect for file'''
+        filepath = self.get_path(id)
+        resp = flask.send_file(filepath)
+        _add_download_headers(filepath, self.mimetype, resp)
+        return resp
+
+    def metadata(self,
+                 id: str,
+                 filename: Optional[str] = None
+                 ) -> Union[dict[str, Any], IOError]:
+        ''' Return meta details of file'''
+        try:
+            filepath = self.get_path(id)
+            if self.mimetype:
+                content_type = self.mimetype
+            elif self.url:
+                content_type = mimetypes.guess_type(self.url)[0]
+            else:
+                raise IOError("No resource URL found")
+            hash, length = _file_hashnlength(filepath)
+            return {'content_type': content_type, 'size': length, 'hash': hash}
+        except IOError as e:
+            log.error("Could not retrieve metadata, IOError thrown: %s", e)
+            return e

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -9,12 +9,11 @@ from typing import Any, Union, Type, cast
 
 import sqlalchemy as sqla
 
-import ckan.lib.jobs as jobs
+from ckan.lib import api_token, jobs, uploader
 import ckan.logic
 import ckan.logic.action
 import ckan.logic.schema
 import ckan.plugins as plugins
-import ckan.lib.api_token as api_token
 from ckan import authz
 from  ckan.lib.navl.dictization_functions import validate
 from ckan.model.follower import ModelFollowingModel
@@ -184,6 +183,15 @@ def resource_delete(context: Context, data_dict: DataDict) -> ActionResult.Resou
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.before_resource_delete(context, data_dict,
                                       pkg_dict.get('resources', []))
+
+    # Delete file if it was uploaded
+    if pkg_dict.get('url_type') == 'upload':
+        upload = uploader.get_resource_uploader(pkg_dict)
+        # Don't break if old plugin/interface is found
+        if hasattr(upload, "delete"):
+            upload.delete(id)  # type: ignore
+        else:
+            log.warning("%s does not have delete function, could not cleanup: %s", type(upload).__name__, id)
 
     package_show_context: Union[Context, Any] = dict(context, for_update=True)
     pkg_dict = _get_action('package_show')(

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -16,22 +16,17 @@ from sqlalchemy import text
 
 
 import ckan
+from ckan import logic, model, plugins
 import ckan.lib.dictization
-import ckan.logic as logic
 import ckan.logic.action
 import ckan.logic.schema
 import ckan.lib.dictization.model_dictize as model_dictize
-import ckan.lib.jobs as jobs
+from ckan.lib import datapreview, jobs, plugins as lib_plugins, search, uploader
 import ckan.lib.navl.dictization_functions
-import ckan.model as model
 import ckan.model.misc as misc
-import ckan.plugins as plugins
-import ckan.lib.search as search
 from ckan.model.follower import ModelFollowingModel
 from ckan.lib.search.query import solr_literal
 
-import ckan.lib.plugins as lib_plugins
-import ckan.lib.datapreview as datapreview
 import ckan.authz as authz
 
 from ckan.common import _
@@ -1153,6 +1148,46 @@ def resource_view_list(context: Context,
         if datapreview.get_view_plugin(resource_view.view_type)
     ]
     return model_dictize.resource_view_list_dictize(resource_views, context)
+
+
+def resource_file_metadata_show(
+        context: Context, data_dict: DataDict
+        ) -> Union[dict[str, Any], IOError]:
+    '''Get file metadata from a resource if it was uploaded.
+
+    :param id: the id of the resource
+    :type id: string
+
+    :returns: the meta data of resource file { 'content_type': content_type, 'size': length, 'hash': hash }
+    :rtype: dictionary
+    '''
+    model = context['model']
+    id = _get_or_bust(data_dict, 'id')
+
+    resource = model.Resource.get(id)
+    if not resource:
+        raise NotFound
+    context['resource'] = resource
+
+    _check_access('resource_file_metadata_show', context, data_dict)
+
+    pkg_dict = logic.get_action('package_show')(
+        context,
+        {'id': resource.package.id,
+         'include_tracking': asbool(data_dict.get('include_tracking', False))})
+
+    for resource_dict in pkg_dict['resources']:
+        if resource_dict['id'] == id:
+            break
+    else:
+        log.error('Could not find resource %s after all', id)
+        raise NotFound(_('Resource was not found.'))
+
+    upload = uploader.get_resource_uploader(resource_dict)
+    try:
+        return upload.metadata(id)  # type: ignore
+    except (IOError, AttributeError):
+        raise NotFound
 
 
 def _group_or_org_show(

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -263,6 +263,7 @@ def package_update(
     name_or_id = data_dict.get('id') or data_dict.get('name')
     if name_or_id is None:
         raise ValidationError({'id': _('Missing value')})
+    resources_only = data_dict.pop('resources_only', False)
 
     pkg = model.Package.get(name_or_id)
     if pkg is None:
@@ -305,10 +306,11 @@ def package_update(
         model.Session.rollback()
         raise ValidationError(errors)
 
-    #avoid revisioning by updating directly
-    model.Session.query(model.Package).filter_by(id=pkg.id).update(
-        {"metadata_modified": datetime.datetime.utcnow()})
-    model.Session.refresh(pkg)
+    if not resources_only:
+        #avoid revisioning by updating directly
+        model.Session.query(model.Package).filter_by(id=pkg.id).update(
+            {"metadata_modified": datetime.datetime.utcnow()})
+        model.Session.refresh(pkg)
 
     include_plugin_data = False
     user_obj = context.get('auth_user_obj')
@@ -565,6 +567,7 @@ def package_resource_reorder(
     new_resources = ordered_resources + existing_resources
     package_dict['resources'] = new_resources
 
+    package_dict['resources_only'] = True
     _check_access('package_resource_reorder', context, package_dict)
     _get_action('package_update')(context, package_dict)
 

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -155,6 +155,10 @@ def resource_view_list(context: Context, data_dict: DataDict) -> AuthResult:
     return authz.is_authorized('resource_show', context, data_dict)
 
 
+def resource_file_metadata_show(context: Context, data_dict: DataDict) -> AuthResult:
+    return authz.is_authorized('resource_show', context, data_dict)
+
+
 def group_show(context: Context, data_dict: DataDict) -> AuthResult:
     user = context.get('user')
     group = get_group_object(context, data_dict)

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1812,8 +1812,10 @@ class IUploader(Interface):
 
         ``update_data_dict(data_dict, url_field, file_field, clear_field)``
 
-        Allow the data_dict to be manipulated before it reaches any
-        validators.
+        Allow the data_dict to be manipulated before it reaches any validators.
+        Optionally, this data_dict can have the following attribute set:
+        preserve_filename (boolean):  If false, then the current UTC time
+        (datetime.utcnow) will be prepended to the filename.
 
         :param data_dict: data_dict to be updated
         :type data_dict: dictionary

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1836,6 +1836,30 @@ class IUploader(Interface):
         :param max_size: upload size can be limited by this value in MBs.
         :type max_size: int
 
+        ``delete(filename)``
+
+        Perform a delete.
+
+        :param filename: The filename to use when deleting a file,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``download(filename)``
+
+        Provide redirect url or file stream
+
+        :param filename: The filename to use when downloading a file,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``metadata(filename)``
+
+        Collect metadata of file. Returns dict
+        { 'content_type': content_type, 'size': length, 'hash': hash }
+        Throws IOError if file does not exist
+
+        :param filename: The filename to use when collecting metadata
+        :type filename: string
         '''
 
     def get_resource_uploader(
@@ -1874,6 +1898,37 @@ class IUploader(Interface):
         :param id: resource id
         :type id: string
 
+        ``delete(id, filename)``
+
+        Perform a delete.
+
+        :param id: resource id, used to delete file
+        :type id: string
+        :param filename: The filename to use when storing a resource,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``download(id, filename)``
+
+        Provide redirect url or file stream
+
+        :param id: resource id, used to locate file
+        :type id: string
+        :param filename: The filename to use when storing a resource,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``metadata(id, filename)``
+
+        Collect metadata of resource. Returns dict
+        { 'content_type': content_type, 'size': length, 'hash': hash }
+        Throws IOError if file does not exist
+
+        :param id: resource id, used to locate file
+        :type id: string
+        :param filename: The filename to use when collecting metadata,
+            may be None depending on the storage provider.
+        :type filename: string
         '''
 
 

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -759,6 +759,38 @@ class TestPackageRead(object):
             url_for("dataset.read", id=dataset["name"]), headers=headers, status=403)
         assert 403 == response.status_code
 
+    # Test the 'reveal_deleted_datasets' flag
+    # Allow deleted datasets to return 'not found' even if private ones redirect
+
+    @pytest.mark.ckan_config("ckan.auth.reveal_private_datasets", "True")
+    @pytest.mark.ckan_config("ckan.auth.reveal_deleted_datasets", "False")
+    def test_anonymous_users_cannot_read_deleted_datasets(self, app, sysadmin):
+        organization = factories.Organization()
+        dataset = factories.Dataset(owner_org=organization["id"], private=True)
+        app.post(
+            url_for("dataset.delete", id=dataset["name"]),
+            headers={"Authorization": sysadmin["token"]}
+        )
+        app.get(
+            url_for("dataset.read", id=dataset["name"]),
+            status=404
+        )
+
+    @pytest.mark.ckan_config("ckan.auth.reveal_private_datasets", "True")
+    @pytest.mark.ckan_config("ckan.auth.reveal_deleted_datasets", "False")
+    def test_user_not_in_organization_cannot_read_deleted_datasets(self, app, user, sysadmin):
+        organization = factories.Organization()
+        dataset = factories.Dataset(owner_org=organization["id"], private=True)
+        headers = {"Authorization": user["token"]}
+        app.post(
+            url_for("dataset.delete", id=dataset["name"]),
+            headers={"Authorization": sysadmin["token"]}
+        )
+        app.get(
+            url_for("dataset.read", id=dataset["name"]),
+            headers=headers, status=404
+        )
+
 
 @pytest.mark.usefixtures("non_clean_db")
 class TestPackageDelete(object):
@@ -1341,6 +1373,43 @@ class TestResourceRead(object):
         )
         assert 302 == response.status_code
         assert '/login' in response.headers[u"Location"]
+
+    # Test the 'reveal_deleted_datasets' flag
+    # Allow deleted resources to return 'not found' even if private ones redirect
+
+    @pytest.mark.ckan_config("ckan.auth.reveal_private_datasets", "True")
+    @pytest.mark.ckan_config("ckan.auth.reveal_deleted_datasets", "False")
+    def test_user_not_in_organization_cannot_read_resources_in_deleted_dataset(self, app, user, sysadmin):
+        organization = factories.Organization()
+        dataset = factories.Dataset(owner_org=organization["id"], private=True)
+        resource = factories.Resource(package_id=dataset["id"])
+        headers = {"Authorization": user["token"]}
+
+        app.post(
+            url_for("dataset.delete", id=dataset["name"]),
+            headers={"Authorization": sysadmin["token"]}
+        )
+        app.get(
+            url_for("{}_resource.read".format(dataset["type"]),
+                    id=dataset["id"], resource_id=resource["id"]),
+            headers=headers, status=404
+        )
+
+    @pytest.mark.ckan_config("ckan.auth.reveal_private_datasets", "True")
+    @pytest.mark.ckan_config("ckan.auth.reveal_deleted_datasets", "False")
+    def test_anonymous_users_cannot_read_resources_in_deleted_dataset(self, app, sysadmin):
+        organization = factories.Organization()
+        dataset = factories.Dataset(owner_org=organization["id"], private=True)
+        resource = factories.Resource(package_id=dataset["id"])
+        app.post(
+            url_for("dataset.delete", id=dataset["name"]),
+            headers={"Authorization": sysadmin["token"]}
+        )
+        app.get(
+            url_for("{}_resource.read".format(dataset["type"]),
+                    id=dataset["id"], resource_id=resource['id']),
+            status=404
+        )
 
 
 @pytest.mark.usefixtures("non_clean_db")

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -47,6 +47,7 @@ def set_cache_control_headers_for_response(response: Response) -> Response:
 
     # __no_cache__ should not be present when caching is allowed
     allow_cache = u'__no_cache__' not in request.environ
+    limit_cache_by_cookie = u'__limit_cache_by_cookie__' in request.environ
 
     if u'Pragma' in response.headers:
         del response.headers["Pragma"]
@@ -61,6 +62,10 @@ def set_cache_control_headers_for_response(response: Response) -> Response:
             pass
     else:
         response.cache_control.private = True
+
+    # Invalidate cached pages upon login/logout
+    if limit_cache_by_cookie:
+        response.vary.add("Cookie")
 
     return response
 

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from functools import partial
 from typing_extensions import TypeAlias
 from urllib.parse import urlencode
-from typing import Any, Iterable, Optional, Union
+from typing import Any, cast, Iterable, Optional, Union
 
 from flask import Blueprint
 from flask.views import MethodView
@@ -441,14 +441,20 @@ def read(package_type: str, id: str) -> Union[Response, str]:
         )
     except NotAuthorized:
         if config.get(u'ckan.auth.reveal_private_datasets'):
-            if current_user.is_authenticated:
-                return base.abort(
-                    403, _(u'Unauthorized to read package %s') % id)
-            else:
-                return h.redirect_to(
-                    "user.login",
-                    came_from=h.url_for('{}.read'.format(package_type), id=id)
-                )
+            real_pkg_dict = get_action(u'package_show')(
+                cast(Context, {'model': model, 'ignore_auth': True}),
+                data_dict)
+            if real_pkg_dict.get('state') != 'deleted' or \
+                    config.get(u'ckan.auth.reveal_deleted_datasets'):
+                if current_user.is_authenticated:
+                    return base.abort(
+                        403, _(u'Unauthorized to read package %s') % id)
+                else:
+                    return h.redirect_to(
+                        "user.login",
+                        came_from=h.url_for(
+                            '{}.read'.format(package_type), id=id)
+                    )
         return base.abort(
             404,
             _(u'Dataset not found or you have no permission to view it')

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import cgi
 import json
 import logging
-from typing import Any, Optional, Union
+from typing import Any, cast, Optional, Union
 
 from werkzeug.wrappers.response import Response as WerkzeugResponse
 import flask
@@ -60,22 +60,30 @@ def read(package_type: str, id: str, resource_id: str) -> Union[Response, str]:
         u'auth_user_obj': current_user,
         u'for_view': True
     }
+    data_dict = {u'id': id}
 
     try:
-        package = get_action(u'package_show')(context, {u'id': id})
+        package = get_action(u'package_show')(context, data_dict)
     except NotFound:
         return base.abort(404, _(u'Dataset not found'))
     except NotAuthorized:
         if config.get(u'ckan.auth.reveal_private_datasets'):
-            if current_user.is_authenticated:
-                return base.abort(
-                    403, _(u'Unauthorized to read resource %s') % resource_id)
-            else:
-                return h.redirect_to(
-                    "user.login",
-                    came_from=h.url_for(
-                        '{}_resource.read'.format(package_type),
-                        id=id, resource_id=resource_id))
+            real_pkg_dict = get_action(u'package_show')(
+                cast(Context, {'model': model, 'ignore_auth': True}),
+                data_dict)
+            if real_pkg_dict.get('state') != 'deleted' or \
+                    config.get(u'ckan.auth.reveal_deleted_datasets'):
+                if current_user.is_authenticated:
+                    return base.abort(
+                        403,
+                        _(u'Unauthorized to read resource %s') % resource_id
+                    )
+                else:
+                    return h.redirect_to(
+                        "user.login",
+                        came_from=h.url_for('resource.read',
+                                            id=id, resource_id=resource_id)
+                    )
         return base.abort(
             404,
             _(u'Dataset not found')

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -174,11 +174,19 @@ def download(package_type: str,
 
     if rsc.get(u'url_type') == u'upload':
         upload = uploader.get_resource_uploader(rsc)
-        filepath = upload.get_path(rsc[u'id'])
-        resp = flask.send_file(filepath, download_name=filename)
+        # Don't break if old plugin/interface is found
+        if hasattr(upload, 'download'):
+            try:
+                resp = upload.download(resource_id, filename)  # type: ignore
+            except (IOError, OSError):
+                # includes FileNotFoundError
+                return base.abort(404, _('Resource data not found'))
+        else:
+            filepath = upload.get_path(rsc[u'id'])
+            resp = flask.send_file(filepath, download_name=filename)
 
-        if rsc.get('mimetype'):
-            resp.headers['Content-Type'] = rsc['mimetype']
+            if rsc.get('mimetype'):
+                resp.headers['Content-Type'] = rsc['mimetype']
         signals.resource_download.send(resource_id)
         return resp
 

--- a/ckanext/activity/model/activity.py
+++ b/ckanext/activity/model/activity.py
@@ -224,16 +224,16 @@ def _activities_limit(
     q: QActivity,
     limit: int,
     offset: Optional[int] = None,
-    revese_order: Optional[bool] = False,
+    reverse_order: Optional[bool] = False,
 ) -> QActivity:
     """
     Return an SQLAlchemy query for all activities at an offset with a limit.
 
-    revese_order:
+    reverse_order:
         if we want the last activities before a date, we must reverse the
         order before limiting.
     """
-    if revese_order:
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -313,8 +313,8 @@ def user_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -328,7 +328,7 @@ def user_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results
@@ -390,8 +390,8 @@ def package_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -405,7 +405,7 @@ def package_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results
@@ -541,8 +541,8 @@ def group_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -556,7 +556,7 @@ def group_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results
@@ -600,8 +600,8 @@ def organization_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -615,7 +615,7 @@ def organization_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results
@@ -736,8 +736,8 @@ def dashboard_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -751,7 +751,7 @@ def dashboard_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -58,6 +58,8 @@ _engines: Dict[str, Engine] = {}
 WhereClauses: TypeAlias = "list[tuple[str, dict[str, Any]] | tuple[str]]"
 
 _TIMEOUT = 60000  # milliseconds
+_LOCK_TIMEOUT = 20000
+_LOCK_TIMEOUT_SQL = u"SET lock_timeout = {}".format(_LOCK_TIMEOUT)
 
 # See http://www.postgresql.org/docs/9.2/static/errcodes-appendix.html
 _PG_ERR_CODE = {
@@ -728,14 +730,18 @@ def _drop_indexes(context: Context, data_dict: dict[str, Any],
             AND idx.indisprimary = false
             AND t.relname = :relname
         """.format(unique='true' if unique else 'false')
-    indexes_to_drop = context['connection'].execute(
-        sa.text(sql_get_index_string),
-        {"relname": data_dict['resource_id']}
-    ).fetchall()
-    for index in indexes_to_drop:
-        context['connection'].execute(sa.text(
-            sql_drop_index.format(sa.column(index[0]))
-        ))
+    with context['connection'].begin():
+        indexes_to_drop = context['connection'].execute(
+            sa.text(sql_get_index_string),
+            {"relname": data_dict['resource_id']}
+        ).fetchall()
+
+    with context['connection'].begin():
+        context['connection'].execute(_LOCK_TIMEOUT_SQL)
+        for index in indexes_to_drop:
+            context['connection'].execute(sa.text(
+                sql_drop_index.format(sa.column(index[0]))
+            ))
 
 
 def _get_index_names(connection: Any, resource_id: str):
@@ -1684,7 +1690,7 @@ def _create_fulltext_trigger(connection: Any, resource_id: str):
 def upsert(context: Context, data_dict: dict[str, Any]):
     '''
     This method combines upsert insert and update on the datastore. The method
-    that will be used is defined in the mehtod variable.
+    that will be used is defined in the method variable.
 
     Any error results in total failure! For now pass back the actual error.
     Should be transactional.
@@ -2081,6 +2087,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
 
         with engine.begin() as conn:
             context["connection"] = conn
+            conn.execute(_LOCK_TIMEOUT_SQL)
             # check if table exists
             if 'filters' not in data_dict:
                 conn.execute(sa.text('DROP TABLE {0} CASCADE'.format(
@@ -2125,6 +2132,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
             context['connection'].execute(sa.text(
                 f"SET LOCAL statement_timeout TO {timeout}"
             ))
+            context['connection'].execute(_LOCK_TIMEOUT_SQL)
             result = context['connection'].execute(sa.text(
                 'SELECT * FROM pg_tables WHERE tablename = :table'
             ), {"table": data_dict['resource_id']}).fetchone()
@@ -2380,6 +2388,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
         sql = f'ANALYZE {identifier(resource_id)}'
         with get_write_engine().connect() as conn:
             try:
+                conn.execute(_LOCK_TIMEOUT_SQL)
                 conn.execute(sa.text(sql))
             except DatabaseError as err:
                 raise DatastoreException(err)
@@ -2427,6 +2436,7 @@ def drop_function(name: str, if_exists: bool):
 
 def _write_engine_execute(sql: str):
     with get_write_engine().begin() as conn:
+        conn.execute(_LOCK_TIMEOUT_SQL)
         conn.execute(sa.text(sql))
 
 

--- a/ckanext/datatablesview/assets/vendor/DataTables/i18n/en_AU.json
+++ b/ckanext/datatablesview/assets/vendor/DataTables/i18n/en_AU.json
@@ -1,0 +1,178 @@
+{
+    "emptyTable": "No data available in table",
+    "info": "Showing _START_ to _END_ of _TOTAL_ entries",
+    "infoEmpty": "Showing 0 to 0 of 0 entries",
+    "infoFiltered": "(filtered from _MAX_ total entries)",
+    "infoThousands": ",",
+    "lengthMenu": "Show _MENU_ entries",
+    "loadingRecords": "Loading...",
+    "processing": "Processing...",
+    "search": "Search:",
+    "zeroRecords": "No matching records found",
+    "thousands": ",",
+    "paginate": {
+        "first": "First",
+        "last": "Last",
+        "next": "Next",
+        "previous": "Previous"
+    },
+    "aria": {
+        "sortAscending": ": activate to sort column ascending",
+        "sortDescending": ": activate to sort column descending"
+    },
+    "autoFill": {
+        "cancel": "Cancel",
+        "fill": "Fill all cells with <i>%d<\/i>",
+        "fillHorizontal": "Fill cells horizontally",
+        "fillVertical": "Fill cells vertically"
+    },
+    "buttons": {
+        "collection": "Collection <span class='ui-button-icon-primary ui-icon ui-icon-triangle-1-s'\/>",
+        "colvis": "Column Visibility",
+        "colvisRestore": "Restore visibility",
+        "copy": "Copy",
+        "copyKeys": "Press ctrl or u2318 + C to copy the table data to your system clipboard.<br><br>To cancel, click this message or press escape.",
+        "copySuccess": {
+            "1": "Copied 1 row to clipboard",
+            "_": "Copied %d rows to clipboard"
+        },
+        "copyTitle": "Copy to Clipboard",
+        "csv": "CSV",
+        "excel": "Excel",
+        "pageLength": {
+            "-1": "Show all rows",
+            "1": "Show 1 row",
+            "_": "Show %d rows"
+        },
+        "pdf": "PDF",
+        "print": "Print"
+    },
+    "searchBuilder": {
+        "add": "Add Condition",
+        "button": {
+            "0": "Search Builder",
+            "_": "Search Builder (%d)"
+        },
+        "clearAll": "Clear All",
+        "condition": "Condition",
+        "conditions": {
+            "date": {
+                "after": "After",
+                "before": "Before",
+                "between": "Between",
+                "empty": "Empty",
+                "equals": "Equals",
+                "not": "Not",
+                "notBetween": "Not Between",
+                "notEmpty": "Not Empty"
+            },
+            "number": {
+                "between": "Between",
+                "empty": "Empty",
+                "equals": "Equals",
+                "gt": "Greater Than",
+                "gte": "Greater Than Equal To",
+                "lt": "Less Than",
+                "lte": "Less Than Equal To",
+                "not": "Not",
+                "notBetween": "Not Between",
+                "notEmpty": "Not Empty"
+            },
+            "string": {
+                "contains": "Contains",
+                "empty": "Empty",
+                "endsWith": "Ends With",
+                "equals": "Equals",
+                "not": "Not",
+                "notEmpty": "Not Empty",
+                "startsWith": "Starts With"
+            },
+            "array": {
+                "without": "Without",
+                "notEmpty": "Not Empty",
+                "not": "Not",
+                "contains": "Contains",
+                "empty": "Empty",
+                "equals": "Equals"
+            }
+        },
+        "data": "Data",
+        "deleteTitle": "Delete filtering rule",
+        "leftTitle": "Outdent Criteria",
+        "logicAnd": "And",
+        "logicOr": "Or",
+        "rightTitle": "Indent Criteria",
+        "title": {
+            "0": "Search Builder",
+            "_": "Search Builder (%d)"
+        },
+        "value": "Value"
+    },
+    "searchPanes": {
+        "clearMessage": "Clear All",
+        "collapse": {
+            "0": "SearchPanes",
+            "_": "SearchPanes (%d)"
+        },
+        "count": "{total}",
+        "countFiltered": "{shown} ({total})",
+        "emptyPanes": "No SearchPanes",
+        "loadMessage": "Loading SearchPanes",
+        "title": "Filters Active - %d"
+    },
+    "select": {
+        "1": "%d row selected",
+        "_": "%d rows selected",
+        "cells": {
+            "1": "1 cell selected",
+            "_": "%d cells selected"
+        },
+        "columns": {
+            "1": "1 column selected",
+            "_": "%d columns selected"
+        }
+    },
+    "datetime": {
+        "previous": "Previous",
+        "next": "Next",
+        "hours": "Hour",
+        "minutes": "Minute",
+        "seconds": "Second",
+        "unknown": "-",
+        "amPm": [
+            "am",
+            "pm"
+        ]
+    },
+    "editor": {
+        "close": "Close",
+        "create": {
+            "button": "New",
+            "title": "Create new entry",
+            "submit": "Create"
+        },
+        "edit": {
+            "button": "Edit",
+            "title": "Edit Entry",
+            "submit": "Update"
+        },
+        "remove": {
+            "button": "Delete",
+            "title": "Delete",
+            "submit": "Delete",
+            "confirm": {
+                "_": "Are you sure you wish to delete %d rows?",
+                "1": "Are you sure you wish to delete 1 row?"
+            }
+        },
+        "error": {
+            "system": "A system error has occurred (<a target=\"\\\" rel=\"nofollow\" href=\"\\\">More information<\/a>)."
+        },
+        "multi": {
+            "title": "Multiple Values",
+            "info": "The selected items contain different values for this input. To edit and set all items for this input to the same value, click or tap here, otherwise they will retain their individual values.",
+            "restore": "Undo Changes",
+            "noMulti": "This input can be edited individually, but not part of a group. "
+        }
+    }
+}


### PR DESCRIPTION
Some of our features have already been merged :)
Others have not.

- Add en_AU locale to DataTables
- Add Uploader functions to support multi-plugin integrations eg S3Filestore and Archiver
- Invalidate cached pages on login/logout
- Shorten lock timeouts on Datastore operations to avoid deadlocks
- Convert dict-type Solr fields into plain strings
- Fall back to /dataset if custom package type is not found
- Rename 'Full name' to 'Displayed name'
- Avoid changing package Modified timestamp when reordering resources