### PR TITLE
[QOLSVC-9300] allow sysadmins to view email addresses on profiles

### DIFF
--- a/ckan/templates/user/snippets/info.html
+++ b/ckan/templates/user/snippets/info.html
@@ -75,7 +75,7 @@
               <dd>{{ user.name }}</dd>
             {% endif %}
           </dl>
-          {% if is_myself %}
+          {% if is_myself or is_sysadmin %}
             <dl>
               <dt>{{ _('Email') }} <span class="label label-default" title="{{ _('This means only you can see this') }}">{{ _('Private') }}</span></dt>
               <dd>{{ user.email }}</dd>


### PR DESCRIPTION
- Sysadmins can see emails on the edit form anyway, might as well make it easier
