### PR TITLE
feature: Enable etag and better cache control header settings 

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -53,12 +53,12 @@ jobs:
 
       - name: Init environment
         run: |
-          ckan -c test-core-cypress.ini db init
+          ckan -c test-core-github-actions.ini db init
 
       - name: Run Cypress
         uses: cypress-io/github-action@v6
         with:
-          start: ckan -c test-core-cypress.ini run
+          start: ckan -c test-core-github-actions.ini run
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,129 @@
+name: Pytest
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      split:
+        type: choice
+        options:
+          - '["1"]'
+          - '["1", "2", "3", "4"]'
+        description: 'Number of test splits (set to ["1"])'
+        required: false
+        default: '["1"]'
+      store-duration-generation:
+        type: boolean
+        default: True
+        description: "pytest create store-duration config"
+env:
+  NODE_VERSION: '16'
+  PYTHON_VERSION: '3.9'
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        #split: [ 1, 2, 3, 4 ]
+        split: ${{ fromJson(inputs.split || '["1", "2", "3", "4"]') }}  # Default to 4 splits
+
+    services:
+      ckan_postgres:
+        image: postgres:15
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_USER: ckan_default
+          POSTGRES_PASSWORD: pass
+          POSTGRES_DB: ckan_default
+          PGDATA: "/data"
+
+      ckan_redis:
+        image: redis
+        ports:
+          - 6379:6379
+      ckan_solr:
+        image: ckan/ckan-solr:master
+        ports:
+          - 8983:8983
+
+    env:
+      CKAN_SQLALCHEMY_URL: postgresql://ckan_default:pass@localhost/ckan_test
+      CKAN_SOLR_URL: http://localhost:8983/solr/ckan
+      CKAN_REDIS_URL: redis://localhost:6379/1
+      POSTGRES_USER: ckan_default
+      CKAN_DB: ckan_test
+
+    steps:
+      - name: Setup Database
+        run: |
+          # Database Creation
+          export PGPASSWORD=pass
+          createdb --host=localhost --username=${POSTGRES_USER} --encoding=utf-8 --owner=${POSTGRES_USER} ${CKAN_DB}
+          psql --host=localhost --username=${POSTGRES_USER} --command="CREATE USER datastore_read WITH PASSWORD 'pass' NOSUPERUSER NOCREATEDB NOCREATEROLE;"
+          psql --host=localhost --username=${POSTGRES_USER} --command="CREATE USER datastore_write WITH PASSWORD 'pass' NOSUPERUSER NOCREATEDB NOCREATEROLE;"
+          createdb --host=localhost --username=${POSTGRES_USER} --encoding=utf-8 --owner=datastore_write datastore_test
+          psql --host=localhost --username=${POSTGRES_USER} --dbname=datastore_test --command="CREATE extension tablefunc;"
+
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install deps
+        run: |
+         pip install -U pip
+         pip install -r requirements.txt -r dev-requirements.txt -e.
+         pip check
+
+      - name: Init environment
+        run: |
+          export PGPASSWORD=pass
+          # Database Initialization
+          ckan -c test-core-github-actions.ini datastore set-permissions | psql --host=localhost --username=${POSTGRES_USER}
+          ckan -c test-core-github-actions.ini db init
+
+          echo "unzip pytest test duration details"
+          gunzip .test_durations.gz
+
+      - name: Run pytest
+        if: inputs.store-duration-generation != 'true'
+        run: |
+          mkdir -p ./junit/result
+          pytest -v --ckan-ini=test-core-github-actions.ini --cov=ckan --cov=ckanext --junitxml=./junit/result/junit.xml --splits 4 --group ${{ matrix.split }} --splitting-algorithm least_duration
+          #pytest -v --ckan-ini=test-core-github-actions.ini --cov=ckan --cov=ckanext --junitxml=./junit/result/junit.xml
+
+      - name: Run pytest (store durations)
+        if: inputs.store-duration-generation == 'true'
+        run:  pytest -v --ckan-ini=test-core-github-actions.ini --cov=ckan --cov=ckanext --junitxml=./junit/result/junit.xm --store-durations
+
+      - name: Store test_durations results
+        if: inputs.store-duration-generation == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: test_durations-${{ matrix.split }}
+          path: ./.test_durations
+
+      - name: Store test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-results-${{ matrix.split }}
+          path: ./junit
+
+
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "./junit/result/*.xml"
+        if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,11 @@ tmp/*
 solr_runtime/*
 fl_notes.txt
 *.ini
+!test-core.ini
+!test-core-circle-ci.ini
+!test-core-cypress.ini
+!test-core-docker.ini
+!test-core-github-actions.ini
 !ckan/migration/alembic.ini
 .noseids
 *~

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -326,7 +326,7 @@ groups:
         default: 31_536_000 # 1 year
         description: |
           If :ref:`SESSION_PERMANENT` is enabled, the session’s expiration will be
-          set this number of seconds in the future. Note that you can not set a 
+          set this number of seconds in the future. Note that you can not set a
           session that never expires (only very far into the future).
 
       - key: SESSION_USE_SIGNER
@@ -408,8 +408,32 @@ groups:
         description: |
           This enables cache control headers on all requests. If the user is
           not logged in and there is no session data a ``Cache-Control:
-          public`` header will be added. For all other requests the
-          ``Cache-control: private`` header will be added.
+          public`` header will be added. For all other requests see ``ckan.cache_private_enabled``
+          config option.
+
+      - key: ckan.cache_private_enabled
+        type: bool
+        default: true
+        example: "true"
+        description: |
+          When this is set to true and ``__no_cache__`` is set on requests,
+          then ``Cache-control: private`` header will be added,
+          else ``Cache-Control: no-cache no-store must-revalidate max-age=0``, ``Expires: 0``
+
+      - key: ckan.cache_etags
+        type: bool
+        default: true
+        example: "true"
+        description: |
+          Add etag response header on all payloads
+
+      - key: ckan.cache_etags_notModified
+        type: bool
+        default: true
+        example: "true"
+        description: |
+          When `ckan.cache_etags` is enabled, then if request `if_none_match` match's response etag, return a 302 not
+          modified instead of the full payload.
 
       - key: ckan.mimetype_guess
         default: file_ext

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -53,6 +53,7 @@ from ckan.views import (identify_user,
                         set_cors_headers_for_response,
                         set_controller_and_action,
                         set_cache_control_headers_for_response,
+                        set_etag_and_fast_304_response_if_unchanged,
                         handle_i18n,
                         set_ckan_current_url,
                         _get_user_for_apitoken,
@@ -393,6 +394,9 @@ def ckan_after_request(response: Response) -> Response:
 
     # Set Cache Control headers
     response = set_cache_control_headers_for_response(response)
+
+    # Set ETag headers and unchanged response if config allows it
+    response = set_etag_and_fast_304_response_if_unchanged(response)
 
     r_time = time.time() - g.__timer
     url = request.environ['PATH_INFO']

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -130,6 +130,10 @@ def _allow_caching(cache_force: Optional[bool] = None):
     # Any rendered template will have a login-sensitive header
     request.environ['__limit_cache_by_cookie__'] = True
     if not allow_cache:
+        # flag to allow private cache to be disabled
+        if not config.get('ckan.cache_private_enabled', True):
+            request.environ['__no_private_cache__'] = True
+
         # Prevent any further rendering from being cached.
         request.environ['__no_cache__'] = True
 

--- a/ckan/tests/lib/test_base.py
+++ b/ckan/tests/lib/test_base.py
@@ -508,3 +508,20 @@ def test_cache_control_while_logged_in(app):
 
     assert 'Cache-Control' in response_headers
     assert response_headers['Cache-Control'] == 'private'
+
+
+@pytest.mark.ckan_config('ckan.cache_enabled', 'true')
+@pytest.mark.ckan_config('ckan.cache_private_enabled', 'false')
+def test_cache_control_while_logged_in_private_cache_disable(app):
+    from ckan.lib.helpers import url_for
+    user = factories.User(password="correct123")
+    identity = {"login": user["name"], "password": "correct123"}
+    request_headers = {}
+
+    response = app.post(
+        url_for("user.login"), data=identity, headers=request_headers
+    )
+    response_headers = dict(response.headers)
+
+    assert 'Cache-Control' in response_headers
+    assert response_headers['Cache-Control'] == 'private'

--- a/ckan/tests/views/test_cache.py
+++ b/ckan/tests/views/test_cache.py
@@ -1,0 +1,129 @@
+import pytest
+import hashlib
+from unittest.mock import patch
+from flask import request
+from ckan.types import Response
+
+import ckan.views as views
+
+
+@pytest.mark.ckan_config("ckan.cache_expires", 3600)
+def test_sets_cache_control_headers_default():
+    """Test that cache control headers are set correctly when caching is allowed."""
+    response = Response("Test content", status=200)
+    with patch.dict(request.environ, {}):
+        updated_response = views.set_cache_control_headers_for_response(response)
+    assert updated_response.cache_control.public is True
+    assert updated_response.cache_control.max_age == 3600
+    assert updated_response.cache_control.must_revalidate is True
+
+
+@pytest.mark.ckan_config("ckan.cache_expires", 3600)
+def test_sets_cache_control_headers_with__no_private_cache__set():
+    """Test that cache control headers are set correctly when caching is allowed."""
+    response = Response("Test content", status=200)
+    with patch.dict(request.environ, {"__no_private_cache__": True}):
+        updated_response = views.set_cache_control_headers_for_response(response)
+    assert updated_response.cache_control.public is True
+    assert updated_response.cache_control.max_age == 3600
+    assert updated_response.cache_control.must_revalidate is True
+
+
+@pytest.mark.ckan_config("ckan.cache_expires", 0)
+def test_disables_cache_when_no_cache_env_present():
+    """Test that no-cache headers are set when `__no_cache__` is true and `__no_private_cache__` is true in the environment."""
+    response = Response("Test content", status=200)
+    with patch.dict(request.environ, {"__no_cache__": True, "__no_private_cache__": True}):
+        updated_response = views.set_cache_control_headers_for_response(response)
+    assert updated_response.cache_control.no_cache is True
+    assert updated_response.cache_control.no_store is True
+    assert updated_response.cache_control.must_revalidate is True
+    assert updated_response.cache_control.max_age == 0
+
+
+@pytest.mark.ckan_config("ckan.cache_expires", 7200)
+def test_sets_private_cache_when___no_cache__is_set_and_no_private_cache_env_present():
+    """Test that private cache is set when `__no_private_cache__` is absent but `__no_cache__` is present."""
+    response = Response("Test content", status=200)
+    with patch.dict(request.environ, {"__no_cache__": True}):
+        updated_response = views.set_cache_control_headers_for_response(response)
+
+    assert updated_response.cache_control.private is True
+    assert updated_response.cache_control.public is None
+
+
+@pytest.mark.ckan_config("ckan.cache_expires", 7200)
+def test_sets_private_cache_when_no_private_cache_env_present():
+    """Test that private cache is set when `__no_private_cache__` is not present but `__no_cache__` is present."""
+    response = Response("Test content", status=200)
+    with patch.dict(request.environ, {"__no_cache__": True}):
+        updated_response = views.set_cache_control_headers_for_response(response)
+    assert updated_response.cache_control.private is True
+    assert updated_response.cache_control.public is None
+
+
+@pytest.mark.ckan_config("ckan.cache_expires", 1800)
+def test_adds_vary_cookie_when_limit_cache_by_cookie_is_present():
+    """Test that `Vary: Cookie` is added when `__limit_cache_by_cookie__` is in the environment."""
+    response = Response("Test content", status=200)
+    with patch.dict(request.environ, {"__limit_cache_by_cookie__": True}):
+        updated_response = views.set_cache_control_headers_for_response(response)
+    assert "Cookie" in updated_response.vary
+
+
+@pytest.mark.ckan_config("ckan.cache_expires", 300)
+def test_removes_pragma_header_if_present():
+    """Test that the `Pragma` header is removed if present in the response."""
+    response = Response("Test content", status=200)
+    response.headers["Pragma"] = "no-cache"
+    updated_response = views.set_cache_control_headers_for_response(response)
+
+    assert "Pragma" not in updated_response.headers
+
+
+@pytest.mark.ckan_config("ckan.cache_etags", True)
+def test_sets_etag_when_missing():
+    """Test that ETag is set if missing in the response headers."""
+    response = Response("Test content", status=200)
+    updated_response = views.set_etag_and_fast_304_response_if_unchanged(response)
+    expected_etag = hashlib.md5(b"Test content").hexdigest()
+    assert updated_response.headers["ETag"] == f'"{expected_etag}"'
+
+
+@pytest.mark.ckan_config("ckan.cache_etags", True)
+def test_does_not_modify_etag_if_already_set():
+    """Test that an existing ETag is not modified."""
+    response = Response("Test content", status=200)
+    response.headers["ETag"] = '"existing-etag"'
+    updated_response = views.set_etag_and_fast_304_response_if_unchanged(response)
+    assert updated_response.headers["ETag"] == '"existing-etag"'
+
+
+@pytest.mark.ckan_config("ckan.cache_etags", True)
+@pytest.mark.ckan_config("ckan.cache_etags_notModified", True)
+def test_returns_304_if_etag_matches(response):
+    """Test that response is changed to 304 Not Modified if ETag matches request."""
+    response = Response("Test content", status=200)
+    etag_value = hashlib.md5(b"Test content").hexdigest()
+    response.headers["ETag"] = f'"{etag_value}"'
+
+    with patch.object(request, "if_none_match", {f'"{etag_value}"'}):
+        updated_response = views.set_etag_and_fast_304_response_if_unchanged(response)
+
+        assert updated_response.status_code == 304
+        assert updated_response.get_data() == b""
+        assert "Content-Length" not in updated_response.headers
+
+
+@pytest.mark.ckan_config("ckan.cache_etags", True)
+@pytest.mark.ckan_config("ckan.cache_etags_notModified", True)
+def test_does_not_return_304_if_etag_does_not_match(response):
+    """Test that response is not modified if request's If-None-Match does not match the ETag."""
+    response = Response("Test content", status=200)
+    response.headers["ETag"] = '"different-etag"'
+
+    with patch.object(request, "if_none_match", {'"some-other-etag"'}):
+        updated_response = views.set_etag_and_fast_304_response_if_unchanged(response)
+
+        assert updated_response.status_code == 200
+        assert updated_response.get_data() == b"Test content"

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
+import hashlib
 from urllib.parse import quote
 from flask.wrappers import Response
 
@@ -43,25 +44,62 @@ def set_cors_headers_for_response(response: Response) -> Response:
     return response
 
 
+def set_etag_and_fast_304_response_if_unchanged(response: Response) -> Response:
+    """Set ETag and return 304 if content is unchanged."""
+
+    enable_etags = config.get(u'ckan.cache_etags', True)
+    enable_etags_not_modified = config.get(u'ckan.cache_etags_notModified', True)
+
+    if response.status_code == 200 and enable_etags:
+        if 'etag' not in response.headers:
+            # s3 etag uses md5, so using it here also
+            etag = hashlib.md5(response.get_data(as_text=True).encode()).hexdigest()
+            response.set_etag(etag)
+        else:
+            etag = response.headers.get('etag')
+
+        # Fast 304 Not Modified response if ETag matches
+        if (enable_etags_not_modified
+                and request.if_none_match
+                and etag is not None):
+            etag_str: str = etag  # Explicit type assertion
+            if request.if_none_match.contains(etag_str):
+                # Remove body for faster response
+                response.status_code = 304
+                response.set_data(b'')
+                # Remove Content-Length for 304
+                response.headers.pop('Content-Length', None)
+
+    return response
+
+
 def set_cache_control_headers_for_response(response: Response) -> Response:
+    """ This uses the presents of request environ's: '__no_cache__',
+    '__no_private_cache__', '__limit_cache_by_cookie__' as well
+    as config variables to control cache response headers"""
 
     # __no_cache__ should not be present when caching is allowed
     allow_cache = u'__no_cache__' not in request.environ
+    # __no_private_cache__ should not be present when private caching is allowed
+    private_cache = u'__no_private_cache__' not in request.environ
+    # __limit_cache_by_cookie__ should not not vary by cookie
     limit_cache_by_cookie = u'__limit_cache_by_cookie__' in request.environ
 
     if u'Pragma' in response.headers:
         del response.headers["Pragma"]
 
+    cache_expire = config.get(u'ckan.cache_expires', 0)
+    response.cache_control.max_age = cache_expire
+    response.cache_control.must_revalidate = True
     if allow_cache:
         response.cache_control.public = True
-        try:
-            cache_expire = config.get(u'ckan.cache_expires')
-            response.cache_control.max_age = cache_expire
-            response.cache_control.must_revalidate = True
-        except ValueError:
-            pass
-    else:
+    elif private_cache:
         response.cache_control.private = True
+    else:
+        response.cache_control.no_cache = True
+        response.cache_control.no_store = True
+        response.cache_control.must_revalidate = True
+        response.cache_control.max_age = 0
 
     # Invalidate cached pages upon login/logout
     if limit_cache_by_cookie:

--- a/test-core-github-actions.ini
+++ b/test-core-github-actions.ini
@@ -1,0 +1,51 @@
+[server:main]
+use = config:test-core.ini
+
+[app:main]
+use = config:test-core.ini
+
+ckan.plugins = activity
+
+ckan.datastore.write_url = postgresql://datastore_write:pass@localhost/datastore_test
+ckan.datastore.read_url = postgresql://datastore_read:pass@localhost/datastore_test
+
+ckan.redis.url = redis://localhost:6379/1
+
+sqlalchemy.url = postgresql://ckan_default:pass@localhost/ckan_test
+
+solr_url = http://localhost:8983/solr/ckan
+
+[loggers]
+keys = root, ckan, sqlalchemy
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_ckan]
+qualname = ckan
+handlers =
+level = INFO
+
+[logger_sqlalchemy]
+handlers =
+qualname = sqlalchemy.engine
+level = WARNING
+# "level = INFO" logs SQL queries.
+# "level = DEBUG" logs SQL queries and results.
+# "level = WARNING" logs neither.
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s


### PR DESCRIPTION


Fixes #

### Proposed fixes:
new config:
ckan.cache_private_enabled: default True
ckan.cache_etags_notModified: default True
ckan.cache_etags: default True


### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
