### PR TITLE
[QOLSVC-11279] add support for psycopg's automatic JSON conversion, #9054

### DIFF
--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -119,7 +119,10 @@ def get_table_and_function_names_from_sql(context: Context, sql: str):
         ))
 
         try:
-            query_plan = json.loads(result)
+            if isinstance(result, list):
+                query_plan = result
+            else:
+                query_plan = json.loads(result)
             plan = query_plan[0]['Plan']
 
             t, q, f = _parse_query_plan(plan)


### PR DESCRIPTION
Per [this documentation](https://www.psycopg.org/docs/extras.html#adapt-json) psycopg will sometimes convert a JSON string into Python objects for us, so ensure we can handle that gracefully.

Couldn't see a way to unit-test this since the psycopg behaviour is built in.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
