### PR TITLE
[QOLSVC-10243] exclude dataset search results from bot indexing

### DIFF
--- a/ckan/templates/base.html
+++ b/ckan/templates/base.html
@@ -26,6 +26,10 @@
       <meta charset="utf-8" />
       <meta name="csrf_field_name" content="{{ g.csrf_field_name }}" />
       <meta name="{{ g.csrf_field_name }}" content="{{ csrf_token() }}" />
+      {# Search result pages shouldn't be indexed by bots. #}
+      {% if has_search_args %}
+        <meta name="robots" content="noindex, follow" />
+      {% endif %}
 
       {% block meta_generator %}<meta name="generator" content="ckan {{ h.ckan_version() }}" />{% endblock %}
       {% block meta_viewport %}<meta name="viewport" content="width=device-width, initial-scale=1.0">{% endblock %}

--- a/ckan/templates/package/search.html
+++ b/ckan/templates/package/search.html
@@ -1,14 +1,6 @@
 {% extends "page.html" %}
 {% import 'macros/form.html' as form %}
 
-{# Search result pages shouldn't be indexed by bots. #}
-{% block meta %}
-    {{ super() }}
-    {% if has_search_args %}
-        <meta name="robots" content="noindex, follow" />
-    {% endif %}
-{% endblock %}
-
 {% block subtitle %}{{ _(dataset_type.title()) }}{% endblock %}
 
 {% block breadcrumb_content %}

--- a/ckan/templates/package/search.html
+++ b/ckan/templates/package/search.html
@@ -1,6 +1,14 @@
 {% extends "page.html" %}
 {% import 'macros/form.html' as form %}
 
+{# Search result pages shouldn't be indexed by bots. #}
+{% block meta %}
+    {{ super() }}
+    {% if has_search_args %}
+        <meta name="robots" content="noindex, follow" />
+    {% endif %}
+{% endblock %}
+
 {% block subtitle %}{{ _(dataset_type.title()) }}{% endblock %}
 
 {% block breadcrumb_content %}

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -213,6 +213,7 @@ def _get_search_details() -> dict[str, Any]:
 def search(package_type: str) -> str:
     extra_vars: dict[str, Any] = {}
 
+    extra_vars['has_search_args'] = True if request.args else False
     extra_vars['q'] = q = request.args.get('q', '')
 
     extra_vars['query_error'] = False

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -130,6 +130,7 @@ def index(group_type: str, is_organization: bool) -> str:
 
     extra_vars["q"] = q
     extra_vars["sort_by_selected"] = sort_by
+    extra_vars['has_search_args'] = True if request.args else False
 
     # pass user info to context as needed to view private datasets of
     # orgs correctly
@@ -388,7 +389,7 @@ def _get_group_dict(id: str, is_organization: bool) -> dict[str, Any]:
 def read(group_type: str,
          is_organization: bool,
          id: Optional[str] = None) -> Union[str, Response]:
-    extra_vars = {}
+    extra_vars: dict[str, Any] = {u'has_search_args': True if request.args else False}
     context: Context = {
         u'user': current_user.name,
         u'schema': _db_to_form_schema(group_type=group_type),


### PR DESCRIPTION
Add a `meta` tag to exclude indexing (but allow following links to sub-pages) any time there are dataset search parameters, #9063