### PR TITLE
[QOLDEV-1221] apply QGOV changes on top of 2.11.4 base

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ defaults:
       CKAN_POSTGRES_USER: ckan_default
       CKAN_POSTGRES_PWD: pass
       PGPASSWORD: ckan
-      PYTEST_COMMON_OPTIONS: -v --ckan-ini=test-core-circle-ci.ini --cov=ckan --cov=ckanext --junitxml=~/junit/result/junit.xml
+      PYTEST_COMMON_OPTIONS: -v --ckan-ini=test-core-ci.ini --cov=ckan --cov=ckanext --junitxml=~/junit/result/junit.xml
       # report usage of deprecated features
       SQLALCHEMY_WARN_20: 1
   pg_image: &pg_image

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,3 +31,10 @@ jobs:
       - name: Create Docs
         run: |
            sphinx-build doc build/sphinx
+
+      #as pytest runs test_building_the_docs, we might as well have an output
+      - name: Store docs
+        uses: actions/upload-artifact@v4
+        with:
+          name: ckan-docs-${{ github.sha }}
+          path: ./build/sphinx

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,35 @@ Changelog
 
 .. towncrier release notes start
 
+v.2.11.x 2025-xx-xx
+==================
+
+Major features
+--------------
+
+- Update to Interface IUploader, on get_uploader and get_resource_uploader,
+  new to include new method signature metadata() which can be utilised by
+  archiver and other plugins instead of trying on local disk directly
+- Add get API `resource_file_metadata_show` which takes resource ID and returns
+  { 'content_type': content_type, 'size': length, 'hash': hash } if found
+- Show "Displayed name" instead of "Full name"
+- Allow sysadmins to see user emails on profile pages
+- Allow the existence of deleted datasets to be hidden from unauthorised access
+  even if private datasets are revealed
+- Delete file on disk when resource is deleted
+- Provide 'Add resource' shortcut on dataset pages alongside 'Manage'
+
+Bugfixes
+--------
+
+- Convert dict values into strings before passing to Solr
+- Add '/dataset' fallback when generating URLs
+- Avoid changing package modified timestamp when reordering resources
+- Shorten the lock timeout on dropping datastore tables to avoid deadlocks
+- Add 'en_AU' locale to DataTables
+- Instruct bots not to index search result pages
+
+
 v.2.11.4 2025-10-29
 ===================
 
@@ -1494,8 +1523,8 @@ Migration notes
   in the server, all users will be logged out of the site**.
   This can happen for instance:
 
-	* if the CKAN container is redeployed in a Docker / cloud setup and the session directory is not persisted
-	* if the sessions are periodically cleaned by an external script
+    * if the CKAN container is redeployed in a Docker / cloud setup and the session directory is not persisted
+    * if the sessions are periodically cleaned by an external script
 
   Here's a summary of the behaviour changes between CKAN versions:
 
@@ -1518,13 +1547,13 @@ Migration notes
   (note that this stores *all* session data, not just the user identifier). This will probably
   be the default behaviour in future CKAN versions::
 
-	# ckan.ini
-	beaker.session.type = cookie
-	beaker.session.validate_key = CHANGE_ME
+    # ckan.ini
+    beaker.session.type = cookie
+    beaker.session.validate_key = CHANGE_ME
 
-	beaker.session.httponly = True
-	beaker.session.secure = True
-	beaker.session.samesite = Lax # or Strict
+    beaker.session.httponly = True
+    beaker.session.secure = True
+    beaker.session.samesite = Lax # or Strict
 
   Alternatively you can configure another persistent backend for the sessions in the server,
   like an SQL Database or Redis (see the `Beaker configuration <https://beaker.readthedocs.io/en/latest/configuration.html>`_
@@ -1771,14 +1800,14 @@ Migration notes
   store the session data in the `client-side cookie <https://beaker.readthedocs.io/en/latest/sessions.html#cookie-based>`_.
   This will probably be the default behaviour in future CKAN versions::
 
-	# ckan.ini
-	beaker.session.type = cookie
+    # ckan.ini
+    beaker.session.type = cookie
     beaker.session.data_serializer = json
-	beaker.session.validate_key = CHANGE_ME
+    beaker.session.validate_key = CHANGE_ME
 
-	beaker.session.httponly = True
-	beaker.session.secure = True
-	beaker.session.samesite = Lax
+    beaker.session.httponly = True
+    beaker.session.secure = True
+    beaker.session.samesite = Lax
     # or Strict, depending on your setup
 
 v.2.9.8 2023-02-15

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -619,6 +619,19 @@ groups:
           If False, all unauthorised requests will receive HTTP 404 Not Found.
           Default is False.
 
+      - key: ckan.auth.reveal_deleted_datasets
+        type: bool
+        default: True
+        description: |
+          Determines whether unauthorised requests for deleted datasets should have
+          the existence of the datasets revealed (True) or hidden (False).
+          This behaves similarly to ckan.auth.reveal_private_datasets; True gives
+          either HTTP 403 Forbidden (if logged in) or a redirect to the login page,
+          while False gives HTTP 404 Not Found. However, it will only take effect
+          if ckan.auth.reveal_private_datasets is already True; otherwise,
+          return HTTP 404 on unauthorised requests regardless of this value.
+          Default is True.
+
       - key: ckan.auth.enable_cookie_auth_in_api
         type: bool
         default: True

--- a/ckan/i18n/en_AU/LC_MESSAGES/ckan.po
+++ b/ckan/i18n/en_AU/LC_MESSAGES/ckan.po
@@ -2,10 +2,10 @@
 # Copyright (C) 2024 ORGANIZATION
 # This file is distributed under the same license as the ckan project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
-# 
+#
 # Translators:
 # Adrià Mercader <amercadero@gmail.com>, 2024
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
@@ -3132,7 +3132,7 @@ msgstr "Change details"
 
 #: ckan/templates/user/edit_user_form.html:17
 msgid "Full name"
-msgstr "Full name"
+msgstr "Displayed name"
 
 #: ckan/templates/user/edit_user_form.html:17
 msgid "eg. Joe Bloggs"
@@ -3304,7 +3304,7 @@ msgstr "username"
 
 #: ckan/templates/user/new_user_form.html:11
 msgid "Full Name"
-msgstr "Full Name"
+msgstr "Displayed name"
 
 #: ckan/templates/user/new_user_form.html:37
 msgid "Create Account"
@@ -3407,7 +3407,7 @@ msgstr "Open ID"
 
 #: ckan/templates/user/snippets/info.html:84
 msgid "This means only you can see this"
-msgstr "This means only you can see this"
+msgstr "This means only yourself and administrators can see this"
 
 #: ckan/templates/user/snippets/info.html:89
 msgid "Member Since"

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -325,6 +325,71 @@ def _get_auto_flask_context():
 
 @core_helper
 def url_for(*args: Any, **kw: Any) -> str:
+    '''Return the URL for an endpoint given some parameters, defaulting to
+    using 'dataset' if the given custom dataset fails.
+
+    This is a wrapper for :py:func:`flask.url_for`
+    and :py:func:`routes.url_for` that adds some extra features that CKAN
+    needs.
+
+    To build a URL for a Flask view, pass the name of the blueprint and the
+    view function separated by a period ``.``, plus any URL parameters::
+        url_for('api.action', ver=3, logic_function='status_show')
+        # Returns /api/3/action/status_show
+
+    For a fully qualified URL pass the ``_external=True`` parameter. This
+    takes the ``ckan.site_url`` and ``ckan.root_path`` settings into account::
+
+        url_for('api.action', ver=3, logic_function='status_show',
+                _external=True)
+
+        # Returns http://example.com/api/3/action/status_show
+
+    URLs built by Pylons use the Routes syntax::
+
+        url_for(controller='my_ctrl', action='my_action', id='my_dataset')
+        # Returns '/dataset/my_dataset'
+
+    Or, using a named route::
+
+        url_for('dataset.read', id='changed')
+        # Returns '/dataset/changed'
+
+    Use ``qualified=True`` for a fully qualified URL when targeting a Pylons
+    endpoint.
+
+    For backwards compatibility, an effort is made to support the Pylons syntax
+    when building a Flask URL, but this support might be dropped in the future,
+    so calls should be updated.
+    '''
+    try:
+        return base_url_for(*args, **kw)
+    except FlaskRouteBuildError:
+        # If the url failed, try again but replace any custom dataset type in
+        #  use with the default 'dataset'
+        retry_with_default = False
+        # Update args if a custom dataset type was set there
+        if (len(args) and '.' in args[0]
+                and not args[0].startswith('/')
+                and not args[0].startswith('dataset.')):
+            args = args[0].split('.', 1)
+            args = ('dataset.' + args[1],)
+            retry_with_default = True
+
+        # Update kw controller if a custom dataset type was set there
+        if (kw.get('controller')
+                and kw.get('controller') != 'dataset'):
+            kw.update({'controller': 'dataset'})
+            retry_with_default = True
+
+        if retry_with_default:
+            return base_url_for(*args, **kw)
+        else:
+            raise
+
+
+@core_helper
+def base_url_for(*args: Any, **kw: Any) -> str:
     '''Return the URL for an endpoint given some parameters.
 
     This is a wrapper for :py:func:`flask.url_for`

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -236,6 +236,9 @@ class PackageSearchIndex(SearchIndex):
                 except DateParserError:
                     log.warning('%r: %r value of %r is not a valid date', pkg_dict['id'], key, value)
                     continue
+            if isinstance(value, dict):
+                # Solr 8+ chokes on passing dict values unless doing an atomic update
+                value = json.dumps(value)
             new_dict[key] = value
 
         pkg_dict = new_dict

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -1,6 +1,8 @@
 # encoding: utf-8
 from __future__ import annotations
 
+import flask
+import hashlib
 import os
 import cgi
 import datetime
@@ -12,12 +14,12 @@ from typing import Any, IO, Optional, Union
 from urllib.parse import urlparse
 
 from werkzeug.datastructures import FileStorage as FlaskFileStorage
+from werkzeug.wrappers.response import Response as WerkzeugResponse
 
-import ckan.lib.munge as munge
-import ckan.logic as logic
-import ckan.plugins as plugins
+from ckan import logic, plugins
 from ckan.common import config
-from ckan.types import ErrorDict, PUploader, PResourceUploader
+from ckan.lib import base, munge
+from ckan.types import ErrorDict, PUploader, PResourceUploader, Response
 
 ALLOWED_UPLOAD_TYPES = (cgi.FieldStorage, FlaskFileStorage)
 MB = 1 << 20
@@ -97,6 +99,36 @@ def get_max_resource_size() -> int:
     return config.get('ckan.max_resource_size')
 
 
+def _file_hashnlength(local_path: str) -> tuple[str, int]:
+    BLOCKSIZE = 65536
+    hasher = hashlib.sha1()
+    length = 0
+
+    with open(local_path, 'rb') as afile:
+        buf = afile.read(BLOCKSIZE)
+        while len(buf) > 0:
+            hasher.update(buf)
+            length += len(buf)
+
+            buf = afile.read(BLOCKSIZE)
+
+    return (str(hasher.hexdigest()), length)
+
+
+def _add_download_headers(file_path: str,
+                          mime_type: Optional[str],
+                          response: Union[Response, WerkzeugResponse]) -> None:
+    """ Add appropriate 'Content-Type' and 'Content-Disposition' headers
+    to a file download.
+    """
+    if mime_type:
+        response.headers['Content-Type'] = mime_type
+    if mime_type != 'application/pdf':
+        file_name = file_path.split('/')[-1]
+        response.headers['Content-Disposition'] = \
+            'attachment; filename=' + file_name
+
+
 class Upload(object):
     storage_path: Optional[str]
     filename: Optional[str]
@@ -137,6 +169,13 @@ class Upload(object):
         if old_filename:
             self.old_filepath = os.path.join(self.storage_path, old_filename)
 
+    def _get_storage_path_for(self, filename: str) -> str:
+        '''Function to get the path to a stored file.
+        Storage path must be configured.
+        '''
+        assert self.storage_path
+        return os.path.join(self.storage_path, filename)
+
     def update_data_dict(self, data_dict: dict[str, Any], url_field: str,
                          file_field: str, clear_field: str) -> None:
         ''' Manipulate data from the data_dict.  url_field is the name of the
@@ -150,6 +189,7 @@ class Upload(object):
         self.clear = data_dict.pop(clear_field, None)
         self.file_field = file_field
         self.upload_field_storage = data_dict.pop(file_field, None)
+        self.preserve_filename = data_dict.get('preserve_filename', None)
 
         if not self.storage_path:
             return
@@ -157,9 +197,11 @@ class Upload(object):
         if isinstance(self.upload_field_storage, ALLOWED_UPLOAD_TYPES):
             if self.upload_field_storage.filename:
                 self.filename = self.upload_field_storage.filename
-                self.filename = str(datetime.datetime.utcnow()) + self.filename
+                if not self.preserve_filename:
+                    self.filename = str(datetime.datetime.utcnow()) \
+                        + self.filename
                 self.filename = munge.munge_filename_legacy(self.filename)
-                self.filepath = os.path.join(self.storage_path, self.filename)
+                self.filepath = self._get_storage_path_for(self.filename)
                 self.upload_file = _get_underlying_file(
                     self.upload_field_storage)
                 self.tmp_filepath = self.filepath + '~'
@@ -206,8 +248,13 @@ class Upload(object):
 
     def verify_type(self):
 
-        if not self.upload_file:
+        if not self.filename or not self.upload_file:
             return
+
+        # if these fields are None when the others are populated
+        # then our code is wrong
+        assert self.upload_field_storage
+        assert self.filepath
 
         allowed_mimetypes = config.get(
             f"ckan.upload.{self.object_type}.mimetypes")
@@ -269,9 +316,42 @@ class Upload(object):
             self.filename = str(Path(self.filename).with_suffix(preferred_extension))
             self.filepath = str(Path(self.filepath).with_suffix(preferred_extension))
 
+    def delete(self, filename: str) -> None:
+        ''' Delete file we are pointing at'''
+        if self.storage_path and not filename.startswith('http'):
+            try:
+                # Delete file from storage_path and filename
+                os.remove(self._get_storage_path_for(filename))
+            except OSError:
+                pass
+
+    def download(self, filename: str) -> Union[Response, WerkzeugResponse]:
+        ''' Generate file stream or redirect for file'''
+        if not self.storage_path:
+            return base.abort(404, "Uploaded resource not found")
+        filepath = self._get_storage_path_for(filename)
+        resp = flask.send_file(filepath)
+        content_type, _ = mimetypes.guess_type(filepath)
+        _add_download_headers(filepath, content_type, resp)
+        return resp
+
+    def metadata(self, filename: str) -> Union[dict[str, Any], IOError]:
+        ''' Return metadata of file'''
+        if not self.storage_path:
+            return {}
+        try:
+            filepath = self._get_storage_path_for(filename)
+            content_type, _ = mimetypes.guess_type(filepath)
+            hash, length = _file_hashnlength(filepath)
+            return {'content_type': content_type, 'size': length, 'hash': hash}
+        except IOError as e:
+            log.error("Could not retrieve meta data, IOError thrown: %s", e)
+            return e
+
 
 class ResourceUpload(object):
     mimetype: Optional[str]
+    url: Optional[str]
 
     def __init__(self, resource: dict[str, Any]) -> None:
         path = get_storage_path()
@@ -297,6 +377,7 @@ class ResourceUpload(object):
 
         if url and config_mimetype_guess == 'file_ext' and urlparse(url).path:
             self.mimetype = mimetypes.guess_type(url)[0]
+        self.url = url
 
         if bool(upload_field_storage) and \
                 isinstance(upload_field_storage, ALLOWED_UPLOAD_TYPES):
@@ -404,3 +485,37 @@ class ResourceUpload(object):
                 os.remove(filepath)
             except OSError:
                 pass
+
+    def delete(self, id: str, filename: Optional[str] = None) -> None:
+        ''' Delete file we are pointing at'''
+        try:
+            os.remove(self.get_path(id))
+        except OSError:
+            pass
+
+    def download(self, id: str, filename: Optional[str] = None
+                 ) -> Union[Response, WerkzeugResponse]:
+        ''' Generate file stream or redirect for file'''
+        filepath = self.get_path(id)
+        resp = flask.send_file(filepath)
+        _add_download_headers(filepath, self.mimetype, resp)
+        return resp
+
+    def metadata(self,
+                 id: str,
+                 filename: Optional[str] = None
+                 ) -> Union[dict[str, Any], IOError]:
+        ''' Return meta details of file'''
+        try:
+            filepath = self.get_path(id)
+            if self.mimetype:
+                content_type = self.mimetype
+            elif self.url:
+                content_type = mimetypes.guess_type(self.url)[0]
+            else:
+                raise IOError("No resource URL found")
+            hash, length = _file_hashnlength(filepath)
+            return {'content_type': content_type, 'size': length, 'hash': hash}
+        except IOError as e:
+            log.error("Could not retrieve metadata, IOError thrown: %s", e)
+            return e

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -9,12 +9,11 @@ from typing import Any, Union, Type, cast
 
 import sqlalchemy as sqla
 
-import ckan.lib.jobs as jobs
+from ckan.lib import api_token, jobs, uploader
 import ckan.logic
 import ckan.logic.action
 import ckan.logic.schema
 import ckan.plugins as plugins
-import ckan.lib.api_token as api_token
 from ckan import authz
 from  ckan.lib.navl.dictization_functions import validate
 from ckan.model.follower import ModelFollowingModel
@@ -184,6 +183,15 @@ def resource_delete(context: Context, data_dict: DataDict) -> ActionResult.Resou
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.before_resource_delete(context, data_dict,
                                       pkg_dict.get('resources', []))
+
+    # Delete file if it was uploaded
+    if data_dict.get('url_type') == 'upload':
+        upload = uploader.get_resource_uploader(data_dict)
+        # Don't break if old plugin/interface is found
+        if hasattr(upload, "delete"):
+            upload.delete(id)  # type: ignore
+        else:
+            log.warning("%s does not have delete function, could not cleanup: %s", type(upload).__name__, id)
 
     package_show_context: Union[Context, Any] = dict(context, for_update=True)
     pkg_dict = _get_action('package_show')(

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -16,23 +16,16 @@ from sqlalchemy import text
 
 
 import ckan
+from ckan import authz, logic, model, plugins
 import ckan.lib.dictization
-import ckan.logic as logic
 import ckan.logic.action
 import ckan.logic.schema
 import ckan.lib.dictization.model_dictize as model_dictize
-import ckan.lib.jobs as jobs
+from ckan.lib import datapreview, jobs, plugins as lib_plugins, search, uploader
 import ckan.lib.navl.dictization_functions
-import ckan.model as model
 import ckan.model.misc as misc
-import ckan.plugins as plugins
-import ckan.lib.search as search
 from ckan.model.follower import ModelFollowingModel
 from ckan.lib.search.query import solr_literal
-
-import ckan.lib.plugins as lib_plugins
-import ckan.lib.datapreview as datapreview
-import ckan.authz as authz
 
 from ckan.common import _
 from ckan.types import ActionResult, Context, DataDict, Query, Schema
@@ -1153,6 +1146,46 @@ def resource_view_list(context: Context,
         if datapreview.get_view_plugin(resource_view.view_type)
     ]
     return model_dictize.resource_view_list_dictize(resource_views, context)
+
+
+def resource_file_metadata_show(
+        context: Context, data_dict: DataDict
+        ) -> Union[dict[str, Any], IOError]:
+    '''Get file metadata from a resource if it was uploaded.
+
+    :param id: the id of the resource
+    :type id: string
+
+    :returns: the meta data of resource file { 'content_type': content_type, 'size': length, 'hash': hash }
+    :rtype: dictionary
+    '''
+    model = context['model']
+    id = _get_or_bust(data_dict, 'id')
+
+    resource = model.Resource.get(id)
+    if not resource:
+        raise NotFound
+    context['resource'] = resource
+
+    _check_access('resource_file_metadata_show', context, data_dict)
+
+    pkg_dict = logic.get_action('package_show')(
+        context,
+        {'id': resource.package.id,
+         'include_tracking': asbool(data_dict.get('include_tracking', False))})
+
+    for resource_dict in pkg_dict['resources']:
+        if resource_dict['id'] == id:
+            break
+    else:
+        log.error('Could not find resource %s after all', id)
+        raise NotFound(_('Resource was not found.'))
+
+    upload = uploader.get_resource_uploader(resource_dict)
+    try:
+        return upload.metadata(id)  # type: ignore
+    except (IOError, AttributeError):
+        raise NotFound
 
 
 def _group_or_org_show(

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -263,6 +263,7 @@ def package_update(
     name_or_id = data_dict.get('id') or data_dict.get('name')
     if name_or_id is None:
         raise ValidationError({'id': _('Missing value')})
+    resources_only = data_dict.pop('resources_only', False)
 
     pkg = model.Package.get(name_or_id)
     if pkg is None:
@@ -306,9 +307,10 @@ def package_update(
         raise ValidationError(errors)
 
     #avoid revisioning by updating directly
-    model.Session.query(model.Package).filter_by(id=pkg.id).update(
-        {"metadata_modified": datetime.datetime.utcnow()})
-    model.Session.refresh(pkg)
+    if not resources_only:
+        model.Session.query(model.Package).filter_by(id=pkg.id).update(
+            {"metadata_modified": datetime.datetime.utcnow()})
+        model.Session.refresh(pkg)
 
     include_plugin_data = False
     user_obj = context.get('auth_user_obj')
@@ -565,6 +567,7 @@ def package_resource_reorder(
     new_resources = ordered_resources + existing_resources
     package_dict['resources'] = new_resources
 
+    package_dict['resources_only'] = True
     _check_access('package_resource_reorder', context, package_dict)
     _get_action('package_update')(context, package_dict)
 

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -155,6 +155,10 @@ def resource_view_list(context: Context, data_dict: DataDict) -> AuthResult:
     return authz.is_authorized('resource_show', context, data_dict)
 
 
+def resource_file_metadata_show(context: Context, data_dict: DataDict) -> AuthResult:
+    return authz.is_authorized('resource_show', context, data_dict)
+
+
 def group_show(context: Context, data_dict: DataDict) -> AuthResult:
     user = context.get('user')
     group = get_group_object(context, data_dict)

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1814,8 +1814,10 @@ class IUploader(Interface):
 
         ``update_data_dict(data_dict, url_field, file_field, clear_field)``
 
-        Allow the data_dict to be manipulated before it reaches any
-        validators.
+        Allow the data_dict to be manipulated before it reaches any validators.
+        Optionally, this data_dict can have the following attribute set:
+        preserve_filename (boolean):  If false, then the current UTC time
+        (datetime.utcnow) will be prepended to the filename.
 
         :param data_dict: data_dict to be updated
         :type data_dict: dictionary
@@ -1838,6 +1840,30 @@ class IUploader(Interface):
         :param max_size: upload size can be limited by this value in MBs.
         :type max_size: int
 
+        ``delete(filename)``
+
+        Perform a delete.
+
+        :param filename: The filename to use when deleting a file,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``download(filename)``
+
+        Provide redirect url or file stream
+
+        :param filename: The filename to use when downloading a file,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``metadata(filename)``
+
+        Collect metadata of file. Returns dict
+        { 'content_type': content_type, 'size': length, 'hash': hash }
+        Throws IOError if file does not exist
+
+        :param filename: The filename to use when collecting metadata
+        :type filename: string
         '''
 
     def get_resource_uploader(
@@ -1876,6 +1902,37 @@ class IUploader(Interface):
         :param id: resource id
         :type id: string
 
+        ``delete(id, filename)``
+
+        Perform a delete.
+
+        :param id: resource id, used to delete file
+        :type id: string
+        :param filename: The filename to use when storing a resource,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``download(id, filename)``
+
+        Provide redirect url or file stream
+
+        :param id: resource id, used to locate file
+        :type id: string
+        :param filename: The filename to use when storing a resource,
+            may be None depending on the storage provider.
+        :type filename: string
+
+        ``metadata(id, filename)``
+
+        Collect metadata of resource. Returns dict
+        { 'content_type': content_type, 'size': length, 'hash': hash }
+        Throws IOError if file does not exist
+
+        :param id: resource id, used to locate file
+        :type id: string
+        :param filename: The filename to use when collecting metadata,
+            may be None depending on the storage provider.
+        :type filename: string
         '''
 
 

--- a/ckan/templates/base.html
+++ b/ckan/templates/base.html
@@ -26,6 +26,10 @@
       <meta charset="utf-8" />
       <meta name="csrf_field_name" content="{{ g.csrf_field_name }}" />
       <meta name="{{ g.csrf_field_name }}" content="{{ csrf_token() }}" />
+      {# Search result pages shouldn't be indexed by bots. #}
+      {% if has_search_args %}
+        <meta name="robots" content="noindex, follow" />
+      {% endif %}
 
       {% block meta_generator %}<meta name="generator" content="ckan {{ h.ckan_version() }}" />{% endblock %}
       {% block meta_viewport %}<meta name="viewport" content="width=device-width, initial-scale=1.0">{% endblock %}

--- a/ckan/templates/package/read_base.html
+++ b/ckan/templates/package/read_base.html
@@ -14,6 +14,7 @@
 
 {% block content_action %}
   {% if h.check_access('package_update', {'id':pkg.id }) %}
+    {% link_for _('Add new resource'), named_route=pkg.type ~ '_resource.new', id=pkg.name, class_='btn btn-primary', icon='plus' %}
     {% link_for _('Manage'), named_route=pkg.type ~ '.edit', id=pkg.name, class_='btn btn-default', icon='wrench' %}
   {% endif %}
 {% endblock %}

--- a/ckan/templates/user/snippets/info.html
+++ b/ckan/templates/user/snippets/info.html
@@ -75,7 +75,7 @@
               <dd>{{ user.name }}</dd>
             {% endif %}
           </dl>
-          {% if is_myself %}
+          {% if is_myself or is_sysadmin %}
             <dl>
               <dt>{{ _('Email') }} <span class="label label-default" title="{{ _('This means only you can see this') }}">{{ _('Private') }}</span></dt>
               <dd>{{ user.email }}</dd>

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -759,6 +759,38 @@ class TestPackageRead(object):
             url_for("dataset.read", id=dataset["name"]), headers=headers, status=403)
         assert 403 == response.status_code
 
+    # Test the 'reveal_deleted_datasets' flag
+    # Allow deleted datasets to return 'not found' even if private ones redirect
+
+    @pytest.mark.ckan_config("ckan.auth.reveal_private_datasets", "True")
+    @pytest.mark.ckan_config("ckan.auth.reveal_deleted_datasets", "False")
+    def test_anonymous_users_cannot_read_deleted_datasets(self, app, sysadmin):
+        organization = factories.Organization()
+        dataset = factories.Dataset(owner_org=organization["id"], private=True)
+        app.post(
+            url_for("dataset.delete", id=dataset["name"]),
+            headers={"Authorization": sysadmin["token"]}
+        )
+        app.get(
+            url_for("dataset.read", id=dataset["name"]),
+            status=404
+        )
+
+    @pytest.mark.ckan_config("ckan.auth.reveal_private_datasets", "True")
+    @pytest.mark.ckan_config("ckan.auth.reveal_deleted_datasets", "False")
+    def test_user_not_in_organization_cannot_read_deleted_datasets(self, app, user, sysadmin):
+        organization = factories.Organization()
+        dataset = factories.Dataset(owner_org=organization["id"], private=True)
+        headers = {"Authorization": user["token"]}
+        app.post(
+            url_for("dataset.delete", id=dataset["name"]),
+            headers={"Authorization": sysadmin["token"]}
+        )
+        app.get(
+            url_for("dataset.read", id=dataset["name"]),
+            headers=headers, status=404
+        )
+
 
 @pytest.mark.usefixtures("non_clean_db")
 class TestPackageDelete(object):
@@ -1341,6 +1373,43 @@ class TestResourceRead(object):
         )
         assert 302 == response.status_code
         assert '/login' in response.headers[u"Location"]
+
+    # Test the 'reveal_deleted_datasets' flag
+    # Allow deleted resources to return 'not found' even if private ones redirect
+
+    @pytest.mark.ckan_config("ckan.auth.reveal_private_datasets", "True")
+    @pytest.mark.ckan_config("ckan.auth.reveal_deleted_datasets", "False")
+    def test_user_not_in_organization_cannot_read_resources_in_deleted_dataset(self, app, user, sysadmin):
+        organization = factories.Organization()
+        dataset = factories.Dataset(owner_org=organization["id"], private=True)
+        resource = factories.Resource(package_id=dataset["id"])
+        headers = {"Authorization": user["token"]}
+
+        app.post(
+            url_for("dataset.delete", id=dataset["name"]),
+            headers={"Authorization": sysadmin["token"]}
+        )
+        app.get(
+            url_for("{}_resource.read".format(dataset["type"]),
+                    id=dataset["id"], resource_id=resource["id"]),
+            headers=headers, status=404
+        )
+
+    @pytest.mark.ckan_config("ckan.auth.reveal_private_datasets", "True")
+    @pytest.mark.ckan_config("ckan.auth.reveal_deleted_datasets", "False")
+    def test_anonymous_users_cannot_read_resources_in_deleted_dataset(self, app, sysadmin):
+        organization = factories.Organization()
+        dataset = factories.Dataset(owner_org=organization["id"], private=True)
+        resource = factories.Resource(package_id=dataset["id"])
+        app.post(
+            url_for("dataset.delete", id=dataset["name"]),
+            headers={"Authorization": sysadmin["token"]}
+        )
+        app.get(
+            url_for("{}_resource.read".format(dataset["type"]),
+                    id=dataset["id"], resource_id=resource['id']),
+            status=404
+        )
 
 
 @pytest.mark.usefixtures("non_clean_db")

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from functools import partial
 from typing_extensions import TypeAlias
 from urllib.parse import urlencode
-from typing import Any, Iterable, Optional, Union
+from typing import Any, cast, Iterable, Optional, Union
 
 from flask import Blueprint
 from flask.views import MethodView
@@ -213,6 +213,7 @@ def _get_search_details() -> dict[str, Any]:
 def search(package_type: str) -> str:
     extra_vars: dict[str, Any] = {}
 
+    extra_vars['has_search_args'] = True if request.args else False
     extra_vars['q'] = q = request.args.get('q', '')
 
     extra_vars['query_error'] = False
@@ -441,14 +442,20 @@ def read(package_type: str, id: str) -> Union[Response, str]:
         )
     except NotAuthorized:
         if config.get(u'ckan.auth.reveal_private_datasets'):
-            if current_user.is_authenticated:
-                return base.abort(
-                    403, _(u'Unauthorized to read package %s') % id)
-            else:
-                return h.redirect_to(
-                    "user.login",
-                    came_from=h.url_for('{}.read'.format(package_type), id=id)
-                )
+            real_pkg_dict = get_action(u'package_show')(
+                cast(Context, {'model': model, 'ignore_auth': True}),
+                data_dict)
+            if real_pkg_dict.get('state') != 'deleted' or \
+                    config.get(u'ckan.auth.reveal_deleted_datasets'):
+                if current_user.is_authenticated:
+                    return base.abort(
+                        403, _(u'Unauthorized to read package %s') % id)
+                else:
+                    return h.redirect_to(
+                        "user.login",
+                        came_from=h.url_for(
+                            '{}.read'.format(package_type), id=id)
+                    )
         return base.abort(
             404,
             _(u'Dataset not found or you have no permission to view it')

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -130,6 +130,7 @@ def index(group_type: str, is_organization: bool) -> str:
 
     extra_vars["q"] = q
     extra_vars["sort_by_selected"] = sort_by
+    extra_vars["has_search_args"] = True if request.args else False
 
     # pass user info to context as needed to view private datasets of
     # orgs correctly
@@ -195,7 +196,9 @@ def index(group_type: str, is_organization: bool) -> str:
 
 def _read(id: Optional[str], limit: int, group_type: str) -> dict[str, Any]:
     u''' This is common code used by both read and bulk_process'''
-    extra_vars: dict[str, Any] = {}
+    extra_vars: dict[str, Any] = {
+        u'has_search_args': True if request.args else False
+    }
     context: Context = {
         u'user': current_user.name,
         u'schema': _db_to_form_schema(group_type=group_type),
@@ -388,7 +391,6 @@ def _get_group_dict(id: str, is_organization: bool) -> dict[str, Any]:
 def read(group_type: str,
          is_organization: bool,
          id: Optional[str] = None) -> Union[str, Response]:
-    extra_vars = {}
     context: Context = {
         u'user': current_user.name,
         u'schema': _db_to_form_schema(group_type=group_type),
@@ -398,8 +400,6 @@ def read(group_type: str,
 
     # unicode format (decoded from utf8)
     q = request.args.get(u'q', u'')
-
-    extra_vars["q"] = q
 
     limit = config.get('ckan.datasets_per_page')
 
@@ -433,7 +433,7 @@ def read(group_type: str,
     g.q = q
     g.group_dict = group_dict
 
-    extra_vars = _read(id, limit, group_type)
+    extra_vars: dict[str, Any] = _read(id, limit, group_type)
     try:
         am_following = logic.get_action('am_following_group')(
             {'user': current_user.name}, {'id': id}
@@ -828,7 +828,6 @@ class BulkProcessView(MethodView):
         return context
 
     def get(self, id: str, group_type: str, is_organization: bool) -> str:
-        extra_vars = {}
         context = self._prepare(group_type, id)
         data_dict: dict[str, Any] = {u'id': id, u'type': group_type}
         data_dict['include_datasets'] = False
@@ -851,7 +850,7 @@ class BulkProcessView(MethodView):
         # ckan 2.9: Adding variables that were removed from c object for
         # compatibility with templates in existing extensions
         g.group_dict = group_dict
-        extra_vars = _read(id, limit, group_type)
+        extra_vars: dict[str, Any] = _read(id, limit, group_type)
         extra_vars['packages'] = g.page.items
         extra_vars['group_dict'] = group_dict
         extra_vars['group'] = group

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import cgi
 import json
 import logging
-from typing import Any, Optional, Union
+from typing import Any, cast, Optional, Union
 
 from werkzeug.wrappers.response import Response as WerkzeugResponse
 import flask
@@ -60,22 +60,30 @@ def read(package_type: str, id: str, resource_id: str) -> Union[Response, str]:
         u'auth_user_obj': current_user,
         u'for_view': True
     }
+    data_dict = {u'id': id}
 
     try:
-        package = get_action(u'package_show')(context, {u'id': id})
+        package = get_action(u'package_show')(context, data_dict)
     except NotFound:
         return base.abort(404, _(u'Dataset not found'))
     except NotAuthorized:
         if config.get(u'ckan.auth.reveal_private_datasets'):
-            if current_user.is_authenticated:
-                return base.abort(
-                    403, _(u'Unauthorized to read resource %s') % resource_id)
-            else:
-                return h.redirect_to(
-                    "user.login",
-                    came_from=h.url_for(
-                        '{}_resource.read'.format(package_type),
-                        id=id, resource_id=resource_id))
+            real_pkg_dict = get_action(u'package_show')(
+                cast(Context, {'model': model, 'ignore_auth': True}),
+                data_dict)
+            if real_pkg_dict.get('state') != 'deleted' or \
+                    config.get(u'ckan.auth.reveal_deleted_datasets'):
+                if current_user.is_authenticated:
+                    return base.abort(
+                        403,
+                        _(u'Unauthorized to read resource %s') % resource_id
+                    )
+                else:
+                    return h.redirect_to(
+                        "user.login",
+                        came_from=h.url_for('{}_resource.read'.format(package_type),
+                                            id=id, resource_id=resource_id)
+                    )
         return base.abort(
             404,
             _(u'Dataset not found')
@@ -166,11 +174,19 @@ def download(package_type: str,
 
     if rsc.get(u'url_type') == u'upload':
         upload = uploader.get_resource_uploader(rsc)
-        filepath = upload.get_path(rsc[u'id'])
-        resp = flask.send_file(filepath, download_name=filename)
+        # Don't break if old plugin/interface is found
+        if hasattr(upload, 'download'):
+            try:
+                resp = upload.download(resource_id, filename)  # type: ignore
+            except (IOError, OSError):
+                # includes FileNotFoundError
+                return base.abort(404, _('Resource data not found'))
+        else:
+            filepath = upload.get_path(rsc[u'id'])
+            resp = flask.send_file(filepath, download_name=filename)
 
-        if rsc.get('mimetype'):
-            resp.headers['Content-Type'] = rsc['mimetype']
+            if rsc.get('mimetype'):
+                resp.headers['Content-Type'] = rsc['mimetype']
         signals.resource_download.send(resource_id)
         return resp
 

--- a/ckanext/activity/model/activity.py
+++ b/ckanext/activity/model/activity.py
@@ -224,16 +224,16 @@ def _activities_limit(
     q: QActivity,
     limit: int,
     offset: Optional[int] = None,
-    revese_order: Optional[bool] = False,
+    reverse_order: Optional[bool] = False,
 ) -> QActivity:
     """
     Return an SQLAlchemy query for all activities at an offset with a limit.
 
-    revese_order:
+    reverse_order:
         if we want the last activities before a date, we must reverse the
         order before limiting.
     """
-    if revese_order:
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -313,8 +313,8 @@ def user_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -328,7 +328,7 @@ def user_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results
@@ -390,8 +390,8 @@ def package_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -405,7 +405,7 @@ def package_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results
@@ -541,8 +541,8 @@ def group_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -556,7 +556,7 @@ def group_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results
@@ -600,8 +600,8 @@ def organization_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -615,7 +615,7 @@ def organization_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results
@@ -736,8 +736,8 @@ def dashboard_activity_list(
         q = q.filter(Activity.timestamp < before)
 
     # revert sort queries for "only before" queries
-    revese_order = after and not before
-    if revese_order:
+    reverse_order = after and not before
+    if reverse_order:
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
@@ -751,7 +751,7 @@ def dashboard_activity_list(
     results = q.all()
 
     # revert result if required
-    if revese_order:
+    if reverse_order:
         results.reverse()
 
     return results

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -59,6 +59,8 @@ _engines: Dict[str, Engine] = {}
 WhereClauses: TypeAlias = "list[tuple[str, dict[str, Any]] | tuple[str]]"
 
 _TIMEOUT = 60000  # milliseconds
+_LOCK_TIMEOUT = 20000
+_LOCK_TIMEOUT_SQL = sa.text(u"SET lock_timeout = {}".format(_LOCK_TIMEOUT))
 
 # See http://www.postgresql.org/docs/9.2/static/errcodes-appendix.html
 _PG_ERR_CODE = {
@@ -742,6 +744,8 @@ def _drop_indexes(context: Context, data_dict: dict[str, Any],
         sa.text(sql_get_index_string),
         {"relname": data_dict['resource_id']}
     ).fetchall()
+
+    context['connection'].execute(_LOCK_TIMEOUT_SQL)
     for index in indexes_to_drop:
         context['connection'].execute(sa.text(
             sql_drop_index.format(sa.column(index[0]))
@@ -906,6 +910,9 @@ Indexes: TypeAlias = "Optional[list[Union[str, list[str]]]]"
 
 
 def create_indexes(context: Context, data_dict: dict[str, Any]):
+    """ The connection object at context['connection']
+    should already have an active transaction before calling this.
+    """
     connection = context['connection']
 
     indexes: Indexes = cast(Indexes, datastore_helpers.get_list(
@@ -1715,7 +1722,7 @@ def _create_fulltext_trigger(connection: Any, resource_id: str):
 def upsert(context: Context, data_dict: dict[str, Any]):
     '''
     This method combines upsert insert and update on the datastore. The method
-    that will be used is defined in the mehtod variable.
+    that will be used is defined in the method variable.
 
     Any error results in total failure! For now pass back the actual error.
     Should be transactional.
@@ -2112,6 +2119,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
 
         with engine.begin() as conn:
             context["connection"] = conn
+            conn.execute(_LOCK_TIMEOUT_SQL)
             # check if table exists
             if 'filters' not in data_dict:
                 conn.execute(sa.text('DROP TABLE {0} CASCADE'.format(
@@ -2156,6 +2164,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
             context['connection'].execute(sa.text(
                 f"SET LOCAL statement_timeout TO {timeout}"
             ))
+            context['connection'].execute(_LOCK_TIMEOUT_SQL)
             result = context['connection'].execute(sa.text(
                 'SELECT * FROM pg_tables WHERE tablename = :table'
             ), {"table": data_dict['resource_id']}).fetchone()
@@ -2411,6 +2420,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
         sql = f'ANALYZE {identifier(resource_id)}'
         with get_write_engine().connect() as conn:
             try:
+                conn.execute(_LOCK_TIMEOUT_SQL)
                 conn.execute(sa.text(sql))
             except DatabaseError as err:
                 raise DatastoreException(err)
@@ -2458,6 +2468,7 @@ def drop_function(name: str, if_exists: bool):
 
 def _write_engine_execute(sql: str):
     with get_write_engine().begin() as conn:
+        conn.execute(_LOCK_TIMEOUT_SQL)
         conn.execute(sa.text(sql))
 
 

--- a/ckanext/datatablesview/assets/vendor/DataTables/i18n/en_AU.json
+++ b/ckanext/datatablesview/assets/vendor/DataTables/i18n/en_AU.json
@@ -1,0 +1,178 @@
+{
+    "emptyTable": "No data available in table",
+    "info": "Showing _START_ to _END_ of _TOTAL_ entries",
+    "infoEmpty": "Showing 0 to 0 of 0 entries",
+    "infoFiltered": "(filtered from _MAX_ total entries)",
+    "infoThousands": ",",
+    "lengthMenu": "Show _MENU_ entries",
+    "loadingRecords": "Loading...",
+    "processing": "Processing...",
+    "search": "Search:",
+    "zeroRecords": "No matching records found",
+    "thousands": ",",
+    "paginate": {
+        "first": "First",
+        "last": "Last",
+        "next": "Next",
+        "previous": "Previous"
+    },
+    "aria": {
+        "sortAscending": ": activate to sort column ascending",
+        "sortDescending": ": activate to sort column descending"
+    },
+    "autoFill": {
+        "cancel": "Cancel",
+        "fill": "Fill all cells with <i>%d<\/i>",
+        "fillHorizontal": "Fill cells horizontally",
+        "fillVertical": "Fill cells vertically"
+    },
+    "buttons": {
+        "collection": "Collection <span class='ui-button-icon-primary ui-icon ui-icon-triangle-1-s'\/>",
+        "colvis": "Column Visibility",
+        "colvisRestore": "Restore visibility",
+        "copy": "Copy",
+        "copyKeys": "Press ctrl or u2318 + C to copy the table data to your system clipboard.<br><br>To cancel, click this message or press escape.",
+        "copySuccess": {
+            "1": "Copied 1 row to clipboard",
+            "_": "Copied %d rows to clipboard"
+        },
+        "copyTitle": "Copy to Clipboard",
+        "csv": "CSV",
+        "excel": "Excel",
+        "pageLength": {
+            "-1": "Show all rows",
+            "1": "Show 1 row",
+            "_": "Show %d rows"
+        },
+        "pdf": "PDF",
+        "print": "Print"
+    },
+    "searchBuilder": {
+        "add": "Add Condition",
+        "button": {
+            "0": "Search Builder",
+            "_": "Search Builder (%d)"
+        },
+        "clearAll": "Clear All",
+        "condition": "Condition",
+        "conditions": {
+            "date": {
+                "after": "After",
+                "before": "Before",
+                "between": "Between",
+                "empty": "Empty",
+                "equals": "Equals",
+                "not": "Not",
+                "notBetween": "Not Between",
+                "notEmpty": "Not Empty"
+            },
+            "number": {
+                "between": "Between",
+                "empty": "Empty",
+                "equals": "Equals",
+                "gt": "Greater Than",
+                "gte": "Greater Than Equal To",
+                "lt": "Less Than",
+                "lte": "Less Than Equal To",
+                "not": "Not",
+                "notBetween": "Not Between",
+                "notEmpty": "Not Empty"
+            },
+            "string": {
+                "contains": "Contains",
+                "empty": "Empty",
+                "endsWith": "Ends With",
+                "equals": "Equals",
+                "not": "Not",
+                "notEmpty": "Not Empty",
+                "startsWith": "Starts With"
+            },
+            "array": {
+                "without": "Without",
+                "notEmpty": "Not Empty",
+                "not": "Not",
+                "contains": "Contains",
+                "empty": "Empty",
+                "equals": "Equals"
+            }
+        },
+        "data": "Data",
+        "deleteTitle": "Delete filtering rule",
+        "leftTitle": "Outdent Criteria",
+        "logicAnd": "And",
+        "logicOr": "Or",
+        "rightTitle": "Indent Criteria",
+        "title": {
+            "0": "Search Builder",
+            "_": "Search Builder (%d)"
+        },
+        "value": "Value"
+    },
+    "searchPanes": {
+        "clearMessage": "Clear All",
+        "collapse": {
+            "0": "SearchPanes",
+            "_": "SearchPanes (%d)"
+        },
+        "count": "{total}",
+        "countFiltered": "{shown} ({total})",
+        "emptyPanes": "No SearchPanes",
+        "loadMessage": "Loading SearchPanes",
+        "title": "Filters Active - %d"
+    },
+    "select": {
+        "1": "%d row selected",
+        "_": "%d rows selected",
+        "cells": {
+            "1": "1 cell selected",
+            "_": "%d cells selected"
+        },
+        "columns": {
+            "1": "1 column selected",
+            "_": "%d columns selected"
+        }
+    },
+    "datetime": {
+        "previous": "Previous",
+        "next": "Next",
+        "hours": "Hour",
+        "minutes": "Minute",
+        "seconds": "Second",
+        "unknown": "-",
+        "amPm": [
+            "am",
+            "pm"
+        ]
+    },
+    "editor": {
+        "close": "Close",
+        "create": {
+            "button": "New",
+            "title": "Create new entry",
+            "submit": "Create"
+        },
+        "edit": {
+            "button": "Edit",
+            "title": "Edit Entry",
+            "submit": "Update"
+        },
+        "remove": {
+            "button": "Delete",
+            "title": "Delete",
+            "submit": "Delete",
+            "confirm": {
+                "_": "Are you sure you wish to delete %d rows?",
+                "1": "Are you sure you wish to delete 1 row?"
+            }
+        },
+        "error": {
+            "system": "A system error has occurred (<a target=\"\\\" rel=\"nofollow\" href=\"\\\">More information<\/a>)."
+        },
+        "multi": {
+            "title": "Multiple Values",
+            "info": "The selected items contain different values for this input. To edit and set all items for this input to the same value, click or tap here, otherwise they will retain their individual values.",
+            "restore": "Undo Changes",
+            "noMulti": "This input can be edited individually, but not part of a group. "
+        }
+    }
+}

--- a/ckanext/example_iuploader/test/test_plugin.py
+++ b/ckanext/example_iuploader/test/test_plugin.py
@@ -1,4 +1,5 @@
 # encoding: utf-8
+import io
 
 import flask
 import pytest
@@ -10,9 +11,13 @@ import ckan.model as model
 
 import ckan.tests.factories as factories
 import ckanext.example_iuploader.plugin as plugin
-
+from flask import Response
 
 CONTENT = "data"
+
+
+def get_response(*args, **kwargs):
+    return Response(io.BytesIO(CONTENT.encode()), mimetype='text/plain')
 
 
 # Uses a fake filesystem for the uploads to be stored.
@@ -24,10 +29,9 @@ CONTENT = "data"
 @pytest.mark.ckan_config("ckan.plugins", "example_iuploader")
 @pytest.mark.ckan_config("ckan.webassets.path", "/tmp/webassets")
 @pytest.mark.usefixtures("with_plugins", "non_clean_db")
-@patch.object(flask, "send_file", side_effect=[CONTENT])
+@patch.object(flask, "send_file", side_effect=get_response)
 def test_resource_download_iuploader_called(
-        send_file, app, monkeypatch, tmpdir, ckan_config
-):
+        send_file, app, monkeypatch, tmpdir, ckan_config):
     monkeypatch.setitem(ckan_config, u'ckan.storage_path', str(tmpdir))
 
     user = factories.User()


### PR DESCRIPTION
- Add Uploader functions
- Use 'Displayed name' instead of 'Full name'
- Allow sysadmins to view email addresses on profile pages
- Add 'Add resource' button to dataset pages
- Allow deleted datasets to be optionally hidden even when private datasets are shown
- Shorten datastore lock timeouts
- Convert dictionaries to plain text before passing to Solr
- Fall back to '/dataset' when custom dataset type fails
- Avoid changing package modified timestamp when reordering resources
- Instruct bots not to index search result pages

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
