### PR TITLE
[QOLSVC-12786] use 'h2' rather than 'h1' for sidebar elements, #9219

### DIFF
--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -12256,7 +12256,8 @@ td.diff_header {
   margin: 0;
   overflow: auto;
 }
-.context-info h1.heading, .context-info .heading.h1 {
+.context-info h1.heading, .context-info .heading.h1,
+.context-info h2.heading, .context-info .heading.h2 {
   margin: 0 0 5px 0;
   font-size: 18px;
   line-height: 1.3;

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -12256,7 +12256,8 @@ td.diff_header {
   margin: 0;
   overflow: auto;
 }
-.context-info h1.heading, .context-info .heading.h1 {
+.context-info h1.heading, .context-info .heading.h1,
+.context-info h2.heading, .context-info .heading.h2 {
   margin: 0 0 5px 0;
   font-size: 18px;
   line-height: 1.3;

--- a/ckan/templates/development/snippets/context.html
+++ b/ckan/templates/development/snippets/context.html
@@ -5,7 +5,7 @@
         <img src="{{ h.url_for_static('/base/images/placeholder-organization.png') }}" width="200">
       </a>
     </div>
-    <h1 class="heading">{{ title }}</h1>
+    <h2 class="heading">{{ title }}</h2>
     <p class="description">
       {{ h.markdown_extract(lipsum(1), 160) }}
     </p>

--- a/ckan/templates/group/snippets/info.html
+++ b/ckan/templates/group/snippets/info.html
@@ -13,12 +13,12 @@
     </div>
     {% endblock %}
     {% block heading %}
-    <h1 class="heading">
+    <h2 class="heading">
       {{ group.display_name }}
       {% if group.state == 'deleted' %}
         [{{ _('Deleted') }}]
       {% endif %}
-    </h1>
+    </h2>
     {% endblock %}
     {% block description %}
     {% if group.description %}

--- a/ckan/templates/organization/snippets/info.html
+++ b/ckan/templates/organization/snippets/info.html
@@ -23,11 +23,11 @@
         </div>
       {% endblock %}
       {% block heading %}
-      <h1 class="heading">{{ organization.title or organization.name }}
+      <h2 class="heading">{{ organization.title or organization.name }}
         {% if organization.state == 'deleted' %}
           [{{ _('Deleted') }}]
         {% endif %}
-      </h1>
+      </h2>
       {% endblock %}
       {% block description %}
       {% if organization.description %}

--- a/ckan/templates/package/snippets/info.html
+++ b/ckan/templates/package/snippets/info.html
@@ -16,7 +16,7 @@ Example:
         <div class="module-content">
           {% block package_info_inner %}
             {% block heading %}
-              <h1 class="heading">{{ h.dataset_display_name(pkg) }}</h1>
+              <h2 class="heading">{{ h.dataset_display_name(pkg) }}</h2>
             {% endblock %}
             {% block nums %}
               {% set num_followers = h.follow_count('dataset', pkg.id) %}

--- a/ckan/templates/package/snippets/resource_info.html
+++ b/ckan/templates/package/snippets/resource_info.html
@@ -11,7 +11,7 @@ Example:
 <div class="module context-info">
   <div class="module-content">
     {% block page_title %}
-      <h1 class="heading">{{ h.resource_display_name(res) or res.id }}</h1>
+      <h2 class="heading">{{ h.resource_display_name(res) or res.id }}</h2>
     {% endblock %}
     {% block resource_info %}
       <div class="nums">

--- a/ckan/templates/user/snippets/info.html
+++ b/ckan/templates/user/snippets/info.html
@@ -18,7 +18,7 @@
         <div class="image">{{ h.user_image(user.id, size=270) }}</div>
         {% endblock %}
         {% block user_heading %}
-        <h1 class="heading">{{ user.display_name }}</h1>
+        <h2 class="heading">{{ user.display_name }}</h2>
         {% endblock %}
         {% block user_about %}
         {% if about_formatted %}


### PR DESCRIPTION
- Pages should only contain one 'h1'
- Update stylesheet to ensure 'heading' class is applied to h2 as well as h1. (No longer relevant to h1 in core, but plugins might rely on it.)