### PR TITLE
QOLSVC-12515 alphabetical facet sort

### DIFF
--- a/changes/9221.feature
+++ b/changes/9221.feature
@@ -1,0 +1,1 @@
+Sort facet fields alphabetically when 'Show All' is used

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1177,15 +1177,23 @@ def get_facet_items_dict(
             facets.append(dict(active=False, **facet_item))
         elif not exclude_active:
             facets.append(dict(active=True, **facet_item))
-    # Sort descendingly by count and ascendingly by case-sensitive display name
-    sort_facets: Callable[[Any], tuple[int, str]] = lambda it: (
-        -it['count'], it['display_name'].lower())
+
+    if limit is None and getattr(g, 'search_facets_limits', None):
+        limit = g.search_facets_limits.get(facet)
+
+    # zero or negative limit treated as infinite for historical reasons
+    has_limit: bool = limit is not None and limit > 0
+
+    # Follow Solr default behaviour:
+    # If limiting results, sort descendingly by count
+    # and ascendingly by case-insensitive display name;
+    # else sort by display name only.
+    sort_facets: Callable[[Any], tuple[int, str]] = lambda it: \
+        (-it['count'], it['display_name'].lower()) if has_limit \
+        else (it['display_name'].lower())
     facets.sort(key=sort_facets)
-    if hasattr(g, 'search_facets_limits'):
-        if g.search_facets_limits and limit is None:
-            limit = g.search_facets_limits.get(facet)
-    # zero treated as infinite for hysterical raisins
-    if limit is not None and limit > 0:
+
+    if has_limit:
         return facets[:limit]
     return facets
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1184,14 +1184,40 @@ def get_facet_items_dict(
     # zero or negative limit treated as infinite for historical reasons
     has_limit: bool = limit is not None and limit > 0
 
-    # Follow Solr default behaviour:
+    # Retrieve requested sorting behaviour if any.
+    # If not specified, then follow Solr default behaviour:
     # If limiting results, sort descendingly by count
     # and ascendingly by case-insensitive display name;
     # else sort by display name only.
-    sort_facets: Callable[[Any], tuple[int, str]] = lambda it: \
-        (-it['count'], it['display_name'].lower()) if has_limit \
-        else (it['display_name'].lower())
-    facets.sort(key=sort_facets)
+    sort_field = request.args.get(
+        '_{}_sort'.format(facet),
+        'count' if has_limit else 'index'
+    )
+    if ',' in sort_field:
+        parts = sort_field.split(',', maxsplit=1)
+        sort_field = parts[0]
+        descending_sort: bool = parts[1].lower().startswith('desc')
+    else:
+        descending_sort: bool = sort_field == 'count'
+
+    if sort_field == 'index':
+        facets.sort(
+            key=lambda it: it['display_name'].lower(),
+            reverse=descending_sort
+        )
+    elif sort_field == 'count':
+        # can't just use 'reverse' when we want one to be descending
+        # but the other ascending
+        if descending_sort:
+            facets.sort(key=lambda it: (
+                -it['count'],
+                it['display_name'].lower()
+            ))
+        else:
+            facets.sort(key=lambda it: (
+                it['count'],
+                it['display_name'].lower()
+            ))
 
     if has_limit:
         return facets[:limit]

--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -10207,11 +10207,22 @@ a.tag:hover {
   background-color: #f6f6f6;
   border-top: 1px solid #ddd;
   border-bottom: 1px solid #ddd;
+  display: flex;
+  align-items: center;
+  column-gap: 5px;
 }
 .module-heading::after {
   display: block;
   clear: both;
   content: "";
+}
+
+.module-heading nav.sort-content {
+  margin-inline-start: auto;
+}
+
+.sort-content .selected {
+  font-weight: 600;
 }
 
 .module-content {

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -10207,11 +10207,22 @@ a.tag:hover {
   background-color: #f6f6f6;
   border-top: 1px solid #ddd;
   border-bottom: 1px solid #ddd;
+  display: flex;
+  align-items: center;
+  column-gap: 5px;
 }
 .module-heading::after {
   display: block;
   clear: both;
   content: "";
+}
+
+.module-heading nav.sort-content {
+  margin-inline-start: auto;
+}
+
+.sort-content .selected {
+  font-weight: 600;
 }
 
 .module-content {

--- a/ckan/templates/snippets/facet_list.html
+++ b/ckan/templates/snippets/facet_list.html
@@ -46,6 +46,18 @@ Dictionary with search facets
 			<h2 class="module-heading">
 			    <i class="fa fa-filter"></i>
 			    {{ title }}
+			    <nav class="sort-content">
+				<button class="btn btn-tertiary fa-classic fa-sort" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+				    <span class="visually-hidden">Sort content selector</span>
+				</button>
+				<ul class="dropdown-menu">
+				    {% set sorting_param = '_{}_sort'.format(name) %}
+				    {% set current_sort = request.args.get(sorting_param, 'none') %}
+				    <li><a class="dropdown-item{% if current_sort == 'count' or current_sort == 'none' %} selected{% endif %}" href="{{ h.remove_url_param(key=sorting_param, replace='count') }}" data-sort="popular">Popular</a></li>
+				    <li><a class="dropdown-item{% if current_sort == 'index' %} selected{% endif %}" href="{{ h.remove_url_param(key=sorting_param, replace='index') }}" data-sort="ascending">Ascending</a></li>
+				    <li><a class="dropdown-item{% if current_sort == 'index,desc' %} selected{% endif %}" href="{{ h.remove_url_param(key=sorting_param, replace='index,desc') }}" data-sort="descending">Descending</a></li>
+				</ul>
+			    </nav>
 			</h2>
 		    {% endblock %}
 		    {% block facet_list_items %}

--- a/ckan/templates/snippets/facet_list.html
+++ b/ckan/templates/snippets/facet_list.html
@@ -37,81 +37,80 @@ Dictionary with search facets
 
 #}
 {% block facet_list %}
-    {% set hide_empty = hide_empty or false %}
-    {% with items = items or h.get_facet_items_dict(name, search_facets) %}
-	{% if items or not hide_empty %}
-	    {% block facet_list_item %}
-		<section class="module module-narrow module-shallow">
-		    {% block facet_list_heading %}
-			<h2 class="module-heading">
-			    <i class="fa fa-filter"></i>
-			    {{ title }}
-			    <nav class="sort-content" aria-label="{{ name }}">
-				{% set sorting_param = '_{}_sort'.format(name) %}
-				{% set current_sort = request.args.get(sorting_param, 'count') %}
-				{% if current_sort == 'count' %}
-					{% set sort_icon = 'fa-arrow-down-wide-short' %}
-					{% set current_sort_label = 'sorted by popularity' %}
-				{% elif current_sort == 'index' %}
-					{% set sort_icon = 'fa-arrow-down-a-z' %}
-					{% set current_sort_label = 'in alphabetical order' %}
-				{% elif current_sort == 'index,desc' %}
-					{% set sort_icon = 'fa-arrow-down-z-a' %}
-					{% set current_sort_label = 'in reverse alphabetical order' %}
-				{% else %}
-					{% set sort_icon = 'fa-sort' %}
-					{% set current_sort_label = 'not sorted' %}
-				{% endif %}
-				<button class="btn btn-tertiary fa-solid {{ sort_icon }}" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Filters for {{ name }} are currently {{ current_sort_label}}">
-				    <span class="visually-hidden">Select a different order for {{ name }} filters</span>
-				</button>
-				<ul class="dropdown-menu">
-				    <li><a class="dropdown-item{% if current_sort == 'count' %} selected{% endif %}" href="{{ h.remove_url_param(key=sorting_param, replace='count') }}" data-sort="popular">Popular</a></li>
-				    <li><a class="dropdown-item{% if current_sort == 'index' %} selected{% endif %}" href="{{ h.remove_url_param(key=sorting_param, replace='index') }}" data-sort="ascending">Ascending</a></li>
-				    <li><a class="dropdown-item{% if current_sort == 'index,desc' %} selected{% endif %}" href="{{ h.remove_url_param(key=sorting_param, replace='index,desc') }}" data-sort="descending">Descending</a></li>
-				</ul>
-			    </nav>
-			</h2>
-		    {% endblock %}
-		    {% block facet_list_items %}
-			{% with items = items or h.get_facet_items_dict(name, search_facets) %}
-			    {% if items %}
-				<nav aria-label="{{ title }}">
-				    <ul class="list-unstyled nav nav-simple nav-facet">
-					{% for item in items %}
-					    {% set href = h.remove_url_param(name, item.name, extras=extras, alternative_url=alternative_url) if item.active else h.add_url_param(new_params={name: item.name}, extras=extras, alternative_url=alternative_url) %}
-					    {% set label = label_function(item) if label_function else item.display_name %}
-					    {% set label_truncated = label|truncate(22) if not label_function else label %}
-					    {% set count = count_label(item['count']) if count_label else ('%d' % item['count']) %}
-					    <li class="nav-item {% if item.active %} active{% endif %}">
-						<a href="{{ href }}" title="{{ label if label != label_truncated else '' }}">
-						    <span class="item-label">{{ label_truncated }}</span>
-						    <span class="hidden separator"> - </span>
-						    <span class="item-count badge">{{ count }}</span>
+	{% set hide_empty = hide_empty or false %}
+	{% with items = items or h.get_facet_items_dict(name, search_facets) %}
+		{% if items or not hide_empty %}
+			{% block facet_list_item %}
+				<section class="module module-narrow module-shallow">
+					{% block facet_list_heading %}
+						<h2 class="module-heading">
+							<i class="fa fa-filter"></i>
+							{{ title }}
+							<nav class="sort-content" aria-label="{{ name }}">
+								{% set sorting_param = '_{}_sort'.format(name) %}
+								{% set current_sort = request.args.get(sorting_param, 'count') %}
+								{% if current_sort == 'count' %}
+									{% set sort_icon = 'fa-arrow-down-wide-short' %}
+									{% set current_sort_label = 'sorted by popularity' %}
+								{% elif current_sort == 'index' %}
+									{% set sort_icon = 'fa-arrow-down-a-z' %}
+									{% set current_sort_label = 'in alphabetical order' %}
+								{% elif current_sort == 'index,desc' %}
+									{% set sort_icon = 'fa-arrow-down-z-a' %}
+									{% set current_sort_label = 'in reverse alphabetical order' %}
+								{% else %}
+									{% set sort_icon = 'fa-sort' %}
+									{% set current_sort_label = 'not sorted' %}
+								{% endif %}
+								<button class="btn btn-tertiary fa-solid {{ sort_icon }}" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Filters for {{ name }} are currently {{ current_sort_label}}">
+									<span class="visually-hidden">Select a different order for {{ name }} filters</span>
+								</button>
+								<ul class="dropdown-menu">
+									<li><a class="dropdown-item{% if current_sort == 'count' %} selected{% endif %}" href="{{ h.remove_url_param(key=sorting_param, replace='count') }}" data-sort="popular">Popular</a></li>
+									<li><a class="dropdown-item{% if current_sort == 'index' %} selected{% endif %}" href="{{ h.remove_url_param(key=sorting_param, replace='index') }}" data-sort="ascending">Ascending</a></li>
+									<li><a class="dropdown-item{% if current_sort == 'index,desc' %} selected{% endif %}" href="{{ h.remove_url_param(key=sorting_param, replace='index,desc') }}" data-sort="descending">Descending</a></li>
+								</ul>
+							</nav>
+						</h2>
+					{% endblock %}
+					{% block facet_list_items %}
+						{% with items = items or h.get_facet_items_dict(name, search_facets) %}
+							{% if items %}
+								<nav aria-label="{{ title }}">
+									<ul class="list-unstyled nav nav-simple nav-facet">
+										{% for item in items %}
+											{% set href = h.remove_url_param(name, item.name, extras=extras, alternative_url=alternative_url) if item.active else h.add_url_param(new_params={name: item.name}, extras=extras, alternative_url=alternative_url) %}
+											{% set label = label_function(item) if label_function else item.display_name %}
+											{% set label_truncated = label|truncate(22) if not label_function else label %}
+											{% set count = count_label(item['count']) if count_label else ('%d' % item['count']) %}
+											<li class="nav-item {% if item.active %} active{% endif %}">
+												<a href="{{ href }}" title="{{ label if label != label_truncated else '' }}">
+													<span class="item-label">{{ label_truncated }}</span>
+													<span class="hidden separator"> - </span>
+													<span class="item-count badge">{{ count }}</span>
+														{% if item.active %}<span class="facet-close"> <i class="fa fa-solid fa-circle-xmark"></i></span>{% endif %}
+												</a>
+											</li>
+										{% endfor %}
+									</ul>
+								</nav>
 
-							{% if item.active %}<span class="facet-close"> <i class="fa fa-solid fa-circle-xmark"></i></span>{% endif %}
-						</a>
-					    </li>
-					{% endfor %}
-				    </ul>
-				</nav>
-
-				<p class="module-footer">
-				    {% if h.get_param_int('_%s_limit' % name) %}
-					{% if h.has_more_facets(name, search_facets) %}
-					    <a href="{{ h.remove_url_param('_%s_limit' % name, replace=0, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _('Show More {facet_type}').format(facet_type=title) }}</a>
-					{% endif %}
-				    {% else %}
-					<a href="{{ h.remove_url_param('_%s_limit' % name, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _('Show Only Popular {facet_type}').format(facet_type=title) }}</a>
-				    {% endif %}
-				</p>
-			    {% else %}
-				<p class="module-content empty">{{ _('There are no {facet_type} that match this search').format(facet_type=title) }}</p>
-			    {% endif %}
-			{% endwith %}
-		    {% endblock %}
-		</section>
-	    {% endblock %}
-	{% endif %}
-    {% endwith %}
+								<p class="module-footer">
+									{% if h.get_param_int('_%s_limit' % name) %}
+										{% if h.has_more_facets(name, search_facets) %}
+											<a href="{{ h.remove_url_param('_%s_limit' % name, replace=0, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _('Show More {facet_type}').format(facet_type=title) }}</a>
+										{% endif %}
+									{% else %}
+										<a href="{{ h.remove_url_param('_%s_limit' % name, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _('Show Only Popular {facet_type}').format(facet_type=title) }}</a>
+									{% endif %}
+								</p>
+							{% else %}
+								<p class="module-content empty">{{ _('There are no {facet_type} that match this search').format(facet_type=title) }}</p>
+							{% endif %}
+						{% endwith %}
+					{% endblock %}
+				</section>
+			{% endblock %}
+		{% endif %}
+	{% endwith %}
 {% endblock %}

--- a/ckan/templates/snippets/facet_list.html
+++ b/ckan/templates/snippets/facet_list.html
@@ -47,13 +47,26 @@ Dictionary with search facets
 			    <i class="fa fa-filter"></i>
 			    {{ title }}
 			    <nav class="sort-content">
-				<button class="btn btn-tertiary fa-classic fa-sort" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-				    <span class="visually-hidden">Sort content selector</span>
+				{% set sorting_param = '_{}_sort'.format(name) %}
+				{% set current_sort = request.args.get(sorting_param, 'count') %}
+				{% if current_sort == 'count' %}
+					{% set sort_icon = 'fa-arrow-down-wide-short' %}
+					{% set current_sort_label = 'sorted by popularity' %}
+				{% elif current_sort == 'index' %}
+					{% set sort_icon = 'fa-arrow-down-a-z' %}
+					{% set current_sort_label = 'in alphabetical order' %}
+				{% elif current_sort == 'index,desc' %}
+					{% set sort_icon = 'fa-arrow-down-z-a' %}
+					{% set current_sort_label = 'in reverse alphabetical order' %}
+				{% else %}
+					{% set sort_icon = 'fa-sort' %}
+					{% set current_sort_label = 'not sorted' %}
+				{% endif %}
+				<button class="btn btn-tertiary fa-solid {{ sort_icon }}" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Filters for {{ name }} are currently {{ current_sort_label}}">
+				    <span class="visually-hidden">Select a different order for {{ name }} filters</span>
 				</button>
 				<ul class="dropdown-menu">
-				    {% set sorting_param = '_{}_sort'.format(name) %}
-				    {% set current_sort = request.args.get(sorting_param, 'none') %}
-				    <li><a class="dropdown-item{% if current_sort == 'count' or current_sort == 'none' %} selected{% endif %}" href="{{ h.remove_url_param(key=sorting_param, replace='count') }}" data-sort="popular">Popular</a></li>
+				    <li><a class="dropdown-item{% if current_sort == 'count' %} selected{% endif %}" href="{{ h.remove_url_param(key=sorting_param, replace='count') }}" data-sort="popular">Popular</a></li>
 				    <li><a class="dropdown-item{% if current_sort == 'index' %} selected{% endif %}" href="{{ h.remove_url_param(key=sorting_param, replace='index') }}" data-sort="ascending">Ascending</a></li>
 				    <li><a class="dropdown-item{% if current_sort == 'index,desc' %} selected{% endif %}" href="{{ h.remove_url_param(key=sorting_param, replace='index,desc') }}" data-sort="descending">Descending</a></li>
 				</ul>

--- a/ckan/templates/snippets/facet_list.html
+++ b/ckan/templates/snippets/facet_list.html
@@ -46,7 +46,7 @@ Dictionary with search facets
 			<h2 class="module-heading">
 			    <i class="fa fa-filter"></i>
 			    {{ title }}
-			    <nav class="sort-content">
+			    <nav class="sort-content" aria-label="{{ name }}">
 				{% set sorting_param = '_{}_sort'.format(name) %}
 				{% set current_sort = request.args.get(sorting_param, 'count') %}
 				{% if current_sort == 'count' %}

--- a/ckan/templates/snippets/search_form.html
+++ b/ckan/templates/snippets/search_form.html
@@ -1,4 +1,5 @@
 {% import 'macros/form.html' as form %}
+{% from "macros/form/hidden.html" import hidden %}
 
 {% set placeholder = placeholder if placeholder else _('Search datasets...') %}
 {% set sorting = sorting if sorting else [(_('Name Ascending'), 'name asc'), (_('Name Descending'), 'name desc')] %}
@@ -55,6 +56,12 @@
 
   {% block search_facets %}
     {% if facets %}
+      {% for field in facets.search %}
+        {% set facet_sort_key = '_{}_sort'.format(field) %}
+        {% if facet_sort_key in request.args %}
+          {{ hidden(facet_sort_key, request.args.get(facet_sort_key)) }}
+        {% endif %}
+      {% endfor %}
       <p class="filter-list">
         {% for field in facets.fields %}
           {% set search_facets_items = facets.search.get(field)['items'] if facets.search and field in facets.search else [] %}

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -988,3 +988,31 @@ def test_get_facet_items_dict(test_request_context):
         assert h.get_facet_items_dict('foo', search_facets, 1) == [
             active_facet_result
         ]
+
+    # lexicographical sort
+    with test_request_context(u'?foo=some-value&_foo_sort=index'):
+        assert h.get_facet_items_dict('foo', search_facets) == [
+            inactive_facet_result,
+            active_facet_result
+        ]
+
+    # reverse lexicographical sort
+    with test_request_context(u'?foo=some-value&_foo_sort=index,desc'):
+        assert h.get_facet_items_dict('foo', search_facets) == [
+            active_facet_result,
+            inactive_facet_result
+        ]
+
+    # popularity sort
+    with test_request_context(u'?foo=some-value&_foo_sort=count'):
+        assert h.get_facet_items_dict('foo', search_facets) == [
+            active_facet_result,
+            inactive_facet_result
+        ]
+
+    # reverse popularity sort
+    with test_request_context(u'?foo=some-value&_foo_sort=count,asc'):
+        assert h.get_facet_items_dict('foo', search_facets) == [
+            inactive_facet_result,
+            active_facet_result
+        ]

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -931,3 +931,60 @@ class TestUploadsEnabled:
     @pytest.mark.ckan_config(u"ckan.plugins", "example_iuploader")
     def test_uploads_enabled_when_iuploader_plugin_exists(self):
         assert h.uploads_enabled() is True
+
+
+def test_get_facet_items_dict(test_request_context):
+    search_facets = {'foo': {'items': [
+        {
+            'name': 'some-value',
+            'display_name': 'Some value',
+            'count': 2
+        },
+        {
+            'name': 'some-other-value',
+            'display_name': 'Some other value',
+            'count': 1
+        }
+    ]}}
+    # The active facet has more hits than the inactive,
+    # and is alphabetically later
+    active_facet_result = {
+        'name': 'some-value', 'display_name': 'Some value',
+        'count': 2, 'active': True
+    }
+    inactive_facet_result = {
+        'name': 'some-other-value', 'display_name': 'Some other value',
+        'count': 1, 'active': False
+    }
+
+    with test_request_context(u'?foo=some-value'):
+        # calls that should return no results
+        assert h.get_facet_items_dict(None) == []
+        assert h.get_facet_items_dict('foo', None) == []
+        assert h.get_facet_items_dict('foo', {'foo': {'items': []}}) == []
+        assert h.get_facet_items_dict('baz', search_facets) == []
+
+        # calls that should return results
+
+        # no limit, include active item
+        # should sort alphabetically
+        assert h.get_facet_items_dict('foo', search_facets) == [
+            inactive_facet_result,
+            active_facet_result
+        ]
+
+        # no limit, exclude active item
+        assert h.get_facet_items_dict('foo', search_facets, 0, True) == [
+            inactive_facet_result
+        ]
+
+        # limit greater than total, should sort by popularity
+        assert h.get_facet_items_dict('foo', search_facets, 10) == [
+            active_facet_result,
+            inactive_facet_result
+        ]
+
+        # limit less than total, should sort by popularity
+        assert h.get_facet_items_dict('foo', search_facets, 1) == [
+            active_facet_result
+        ]


### PR DESCRIPTION
Mitigates #9221

### Proposed fixes:

Sort facet fields alphabetically when no limit is being applied, as per standard Solr behaviour: https://solr.apache.org/guide/solr/latest/query-guide/faceting.html

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
