### PR TITLE
[QOLSVC-12515] adjust 'show less' link text to reflect different sorts

### DIFF
--- a/ckan/templates/snippets/facet_list.html
+++ b/ckan/templates/snippets/facet_list.html
@@ -101,7 +101,7 @@ Dictionary with search facets
 											<a href="{{ h.remove_url_param('_%s_limit' % name, replace=0, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _('Show More {facet_type}').format(facet_type=title) }}</a>
 										{% endif %}
 									{% else %}
-										<a href="{{ h.remove_url_param('_%s_limit' % name, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _('Show Only Popular {facet_type}').format(facet_type=title) }}</a>
+										<a href="{{ h.remove_url_param('_%s_limit' % name, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _('Show Less {facet_type}').format(facet_type=title) }}</a>
 									{% endif %}
 								</p>
 							{% else %}


### PR DESCRIPTION
- 'Show Only Popular' doesn't work when not sorting by popularity
