### PR TITLE
[QOLDEV-2051] apply minimum height to logo images

### DIFF
--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -12499,6 +12499,7 @@ td.diff_header {
 }
 .masthead .navbar .logo img {
   max-height: 60px;
+  min-height: 55px;
 }
 .masthead .main-navbar ul {
   padding-right: 20px;

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -12499,6 +12499,7 @@ td.diff_header {
 }
 .masthead .navbar .logo img {
   max-height: 60px;
+  min-height: 55px;
 }
 .masthead .main-navbar ul {
   padding-right: 20px;


### PR DESCRIPTION
Backporting; CKAN master does this, making the Open Data custom logo height redundant
